### PR TITLE
Changes pattern attribute type from integer to string

### DIFF
--- a/migrations/1507147503759-change-size-color.js
+++ b/migrations/1507147503759-change-size-color.js
@@ -27,7 +27,7 @@ module.exports.up = function (next) {
             size: { type: "integer" },
             price: { type: "double" },
             color: { type: "integer" },
-            pattern: { type: "integer" },
+            pattern: { type: "string" },
             id: { type: "integer" },
             status: { type: "integer" },
             weight: { type: "integer" },


### PR DESCRIPTION
Custom magento2-sample-data attribute "pattern" had invalid mapping type (integer). Some values of this attribute were like "123,212" and now it's able to migrate records from `var/catalog.json`.