### PR TITLE
Load default country for tax calculation from config

### DIFF
--- a/src/lib/taxcalc.js
+++ b/src/lib/taxcalc.js
@@ -1,4 +1,4 @@
-export function calculateProductTax (product, taxClasses, taxCountry = 'PL', taxRegion = '') {
+export function calculateProductTax (product, taxClasses, taxCountry, taxRegion = '') {
   let rateFound = false
   let taxClass = taxClasses.find((el) => el.product_tax_class_ids.indexOf(parseInt(product.tax_class_id) >= 0))
   if (taxClass) {

--- a/src/platform/magento2/tax.js
+++ b/src/platform/magento2/tax.js
@@ -4,7 +4,7 @@ const es = require('elasticsearch')
 const bodybuilder = require('bodybuilder')
 
 class TaxProxy extends AbstractTaxProxy {
-    constructor (config, indexName, taxCountry = 'PL', taxRegion = ''){
+    constructor (config, indexName, taxCountry, taxRegion = ''){
         super(config)
         this._indexName = indexName
         this._taxCountry = taxCountry

--- a/src/processor/product.js
+++ b/src/processor/product.js
@@ -16,9 +16,10 @@ class ProductProcessor {
         const processorChain = []
 
         const platform = this._config.platform
-		const factory = new PlatformFactory(this._config)
-		const taxProcessor = factory.getAdapter(platform, 'tax', this._indexName)
-        
+        const factory = new PlatformFactory(this._config)
+        const taxCountry = this._config.tax.defaultCountry
+        const taxProcessor = factory.getAdapter(platform, 'tax', this._indexName, taxCountry)
+
         processorChain.push(taxProcessor.process(items))
 
         return Promise.all(processorChain).then(((resultSet) => {


### PR DESCRIPTION
Hi!

It seems like the defaultCountry set in the config, for tax calculation is ignored. And instead the argument is hardcoded in the function arguments?

I wasn't sure where to resolve the issue, but the product processor seemed like the right place.