### PR TITLE
Official Elastic Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,63 +1,44 @@
 version: '2'
 services:
   es1:
-    image: elasticsearch:5.5
+    build: elasticsearch/
     container_name: es1
     environment:
-      - cluster.name=docker-cluster
-      - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     ulimits:
       memlock:
         soft: -1
         hard: -1
     mem_limit: 1g
     volumes:
+      - ./elasticsearch/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
       - esdat1:/usr/share/elasticsearch/data
     ports:
       - 9200:9200
     networks:
       - esnet
-  es2:
-    image: elasticsearch:5.5
-    environment:
-      - cluster.name=docker-cluster
-      - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - "discovery.zen.ping.unicast.hosts=es1"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-    mem_limit: 1g
-    volumes:
-      - esdat2:/usr/share/elasticsearch/data
-    networks:
-      - esnet
 
   kibana:
-    image: kibana:5.5
+    build: kibana/
+    volumes:
+      - ./kibana/config/:/usr/share/kibana/config
     ports:
       - 5601:5601
-    environment:
-      ELASTICSEARCH_URL: http://es1:9200
     networks:
-        - esnet
+      - esnet
+    depends_on:
+      - es1
 
   redis:  
     image: redis
 
     ports:
-      - "6379:6379"      
+      - "6379:6379"
 
 
 volumes:
   esdat1:
     driver: local
-  esdat2:
-    driver: local
 
 networks:
   esnet:
-
-

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:5.6.9
+
+# Add your elasticsearch plugins setup here
+# Example: RUN elasticsearch-plugin install analysis-icu

--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -1,0 +1,25 @@
+---
+## Default Elasticsearch configuration from elasticsearch-docker.
+## from https://github.com/elastic/elasticsearch-docker/blob/master/build/elasticsearch/elasticsearch.yml
+#
+cluster.name: "docker-cluster"
+network.host: 0.0.0.0
+
+# minimum_master_nodes need to be explicitly set when bound on a public IP
+# set to 1 to allow single node clusters
+# Details: https://github.com/elastic/elasticsearch/pull/17288
+discovery.zen.minimum_master_nodes: 1
+
+## Use single node discovery in order to disable production mode and avoid bootstrap checks
+## see https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html
+#
+discovery.type: single-node
+
+## Disable X-Pack
+## see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
+##     https://www.elastic.co/guide/en/x-pack/current/installing-xpack.html#xpack-enabling
+#
+xpack.security.enabled: false
+xpack.monitoring.enabled: false
+xpack.ml.enabled: false
+xpack.watcher.enabled: false

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/kibana/kibana:5.6.9
+
+# Add your kibana plugins setup here
+# Example: RUN kibana-plugin install <name|url>

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -1,0 +1,18 @@
+---
+## Default Kibana configuration from kibana-docker.
+## from https://github.com/elastic/kibana-docker/blob/master/build/kibana/config/kibana.yml
+#
+server.name: kibana
+server.host: "0"
+elasticsearch.url: http://es1:9200
+
+## Disable X-Pack
+## see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
+##     https://www.elastic.co/guide/en/x-pack/current/installing-xpack.html#xpack-enabling
+#
+xpack.security.enabled: false
+xpack.monitoring.enabled: false
+xpack.ml.enabled: false
+xpack.graph.enabled: false
+xpack.reporting.enabled: false
+xpack.grokdebugger.enabled: false


### PR DESCRIPTION
* Elastic 5.6 (no breaking change)
* Official Elastic Docker image
* Better Elastic configuration handling
* Development mode (single node)