### PR TITLE
Corrected url for check API access.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Catalog API calls are compliant with ElasticSearch (it works like a filtering pr
 
 Elastic search endpoint: `http://localhost:8080/api/catalog/search/<INDEX_NAME>/`. You can run the following command to check if everything is up and runing (it assumes `vue_storefront_catalog` as default index name):
 
-`curl -i http://elastic:changeme@localhost:8080/api/search/vue_storefront_catalog/_search?query=*`
+`curl -i http://elastic:changeme@localhost:8080/api/catalog/vue_storefront_catalog/_search`
 
 ## Data formats
 This backend is using ElasticSearch data formats popularized by [ElasticSuite for Magento2 by Smile.fr](https://github.com/Smile-SA/elasticsuite).


### PR DESCRIPTION
\+ @pkarw  

The current doc url return:
![2018-08-14_09-22-12](https://user-images.githubusercontent.com/414067/44073181-a3bd9ba8-9fa3-11e8-9b17-253a55ac7a6c.png)
 