### PR TITLE
Fixed incorrect commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,19 @@ As a result, all necessary services will be launched:
 Product catalog is imported using [elasticdump](https://www.npmjs.com/package/elasticdump), which is installed automatically via project dependency. The default ElasticSearch index name is: `vue_storefront_catalog`
 
 - (A) `yarn restore`
-- (B) `docker exec -it vuestorefrontapi_app_1 yarn restore`
+- (B) `docker exec -it vue-storefront-api_app_1 yarn restore`
 
 Then, to update the structures in the database to the latest version (data migrations), do the following:
 
 - (A) `yarn migrate`
-- (B) `docker exec -it vuestorefrontapi_app_1 yarn migrate`
+- (B) `docker exec -it vue-storefront-api_app_1 yarn migrate`
 
 By default, the application server is started in development mode. It means that code auto reload is enabled along with ESLint, babel support.
 
 It restores JSON documents stored in `./var/catalog.json`. The opposite command - used to generate `catalog.json` file from running ElasticSearch cluster:
 
 - (A) `yarn dump`
-- (B) `docker exec -it vuestorefrontapi_app_1 yarn dump`
+- (B) `docker exec -it vue-storefront-api_app_1 yarn dump`
 
 **Access ElasticSearch data with Kibana**
 
@@ -89,7 +89,7 @@ To do this, define the `package.json` with your dependencies in your custom modu
 - `src/api/extensions/{your-custom-extension}/package.json` 
 - `src/platforms/{your-custom-platform}/package.json`
 
-Executing `docker exec -it vuestorefrontapi_app_1 yarn install` will also download your custom modules dependencies.
+Executing `docker exec -it vue-storefront-api_app_1 yarn install` will also download your custom modules dependencies.
 
 NOTE: `npm` users will still have to install the dependencies individually in their modules.
 


### PR DESCRIPTION
I found a few typos in the documentations. Corrected the container name to `vue-storefront-api_app_1` instead of `vuestorefrontapi_app_1`

Thanks for all the work you've done so far.