### PR TITLE
Bugfix for missing images in vue storefront

### DIFF
--- a/docker/vue-storefront-api/Dockerfile
+++ b/docker/vue-storefront-api/Dockerfile
@@ -5,6 +5,7 @@ ENV VS_ENV prod
 WORKDIR /var/www
 
 RUN apk add --no-cache imagemagick
+RUN apk add --no-cache curl
 
 COPY package.json ./
 


### PR DESCRIPTION
Adding curl prevents an internal server error when vue-storefront-api tries to retrieve images from magento 2.