### PR TITLE
Changing version in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.0'
 services:
   es1:
     container_name: elasticsearch


### PR DESCRIPTION
Resolves [#111](https://github.com/DivanteLtd/vue-storefront-api/issues/111)

Versions in `docker-compose.yml` and `docker-compose.nodejs.yml` now are the same.