### PR TITLE
Use order schema extension in o2m sync

### DIFF
--- a/src/worker/order_to_magento2.js
+++ b/src/worker/order_to_magento2.js
@@ -8,7 +8,10 @@ const logger = require('./log');
 const countryMapper = require('../lib/countrymapper')
 const Ajv = require('ajv'); // json validator
 const ajv = new Ajv(); // validator
-const validate = ajv.compile(require('../models/order.schema.json'));
+const merge = require('lodash/merge')
+const orderSchema = require('../models/order.schema.json')
+const orderSchemaExtension = require('../models/order.schema.extension.json')
+const validate = ajv.compile(merge(orderSchema, orderSchemaExtension));
 
 const config = require('config')
 let queue = kue.createQueue(Object.assign(config.kue, { redis: config.redis }));


### PR DESCRIPTION
This is an addition which was forgotten in PR #87 

The extended order schema extension needs also to be merged in the order sync. 
The implemented logic is quite the same as in PR #87 


