### PR TITLE
custom field type for news_to_date

### DIFF
--- a/config/elastic.schema.product.json
+++ b/config/elastic.schema.product.json
@@ -33,6 +33,10 @@
            "type": "date",           
            "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
         },
+       "news_to_date": {
+           "type": "date",
+           "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+        },
        "description": {"type": "text"},
        "name": {"type": "text"},
        "configurable_children": {


### PR DESCRIPTION
Missing mapping data type for field "news_to_date". In my elasticsearch index, "news_to_date" have type "string" and can't be filtered by date correctly.