### PR TITLE
bugfix/128 - Exit process on success

### DIFF
--- a/scripts/db.js
+++ b/scripts/db.js
@@ -65,6 +65,7 @@ program
       }
 
       console.log('Done! Bye!')
+      process.exit(0)
     })
   })
 


### PR DESCRIPTION
Call `process.exit()` when successfully creating a new db.