### PR TITLE
Allow custom schemas and resolvers addition from extensions level

### DIFF
--- a/src/graphql/resolvers.js
+++ b/src/graphql/resolvers.js
@@ -2,8 +2,12 @@ import path from 'path';
 import config from 'config';
 import { fileLoader, mergeResolvers } from 'merge-graphql-schemas';
 
-const resolversArray = fileLoader(
+const coreResolvers = fileLoader(
   path.join(__dirname, `./${config.server.searchEngine}/**/resolver.js`)
 );
+const extensionsResolvers = fileLoader(
+  path.join(__dirname, `../api/extensions/**/resolver.js`)
+);
+const resolversArray = coreResolvers.concat(extensionsResolvers)
 
 export default mergeResolvers(resolversArray, { all: true });

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -2,8 +2,12 @@ import path from 'path';
 import config from 'config';
 import { fileLoader, mergeTypes } from 'merge-graphql-schemas';
 
-const typesArray = fileLoader(
+const coreSchemas = fileLoader(
   path.join(__dirname, `./${config.server.searchEngine}/**/*.graphqls`)
 );
+const extensionsSchemas = fileLoader(
+  path.join(__dirname, `../api/extensions/**/*.graphqls`)
+);
+const typesArray = coreSchemas.concat(extensionsSchemas)
 
 export default mergeTypes(typesArray, { all: true });


### PR DESCRIPTION
With this update custom entities could be added through extensions by simply creating  : 
- one or more `*.graphqls` files with the extension schema(s)
- a `resolver.js` file with the extension entity resolvers

**For example :** 
file `src/api/extensions/demo-graphql-extension/schema.graphqls`
```
type Query {
    hello(name: String): String
}
```

file `src/api/extensions/demo-graphql-extension/resolver.js`
```
const resolver = {
  Query: {
    hello: (parent, args) => {
      const { name } = args
      return `hello ${name}`
    }
  }
};

export default resolver;
```

Resolvers and schemas will be merge with the core ones.