### PR TITLE
Allow extensions to be installed as npm modules

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -43,16 +43,22 @@ export default ({ config, db }) => {
 
 	/** Register the custom extensions */
 	for(let ext of config.registeredExtensions) {
+    let entryPoint
 
 		try {
-			let entryPoint = require('./extensions/' + ext)
-			if (entryPoint) {
-				api.use('/ext/' + ext, entryPoint({ config, db }))
-				console.log('Extension ' + ext + ' registered under /ext/' + ext +' base URL')
-			}
+			entryPoint = require('./extensions/' + ext)
 		} catch (err) {
-			console.error(err)
-		}
+      try {
+        entryPoint = require(ext)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+
+    if (entryPoint) {
+      api.use('/ext/' + ext, entryPoint({ config, db }))
+      console.log('Extension ' + ext + ' registered under /ext/' + ext +' base URL')
+    }
 	}
 
 	return api;


### PR DESCRIPTION
This should allow extensions to be included as their own separate module.

Registering works exactly the same so this should be fully backwards compatible, eg:

1. Run `yarn add my-npm-extension`
2. Add `my-npm-extension` to `local.json`'s `registeredExtensions`
3. Restart server

API should be available at: `/api/ext/my-npm-extension/:methodName`

The register method will still check the local `extensions` folder first so they can be overwritten if needed.