### PR TITLE
Adds config variable for excluding disabled products

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -7,6 +7,9 @@
   "orders": {
     "useServerQueue": false
   },
+  "catalog": {
+    "excludeDisabledProducts": false
+  },
   "elasticsearch": {
     "host": "localhost",
     "port": 9200,

--- a/scripts/mage2vs.js
+++ b/scripts/mage2vs.js
@@ -24,6 +24,7 @@ function getMagentoDefaultConfig(storeCode) {
   return {
     TIME_TO_EXIT: 2000,
     PRODUCTS_SPECIAL_PRICES: true,
+    PRODUCTS_EXCLUDE_DISABLED: config.catalog.excludeDisabledProducts,
     MAGENTO_CONSUMER_KEY: apiConfig.consumerKey,
     MAGENTO_CONSUMER_SECRET: apiConfig.consumerSecret,
     MAGENTO_ACCESS_TOKEN: apiConfig.accessToken,


### PR DESCRIPTION
Related to [mage2vuestorefront#61](https://github.com/DivanteLtd/mage2vuestorefront/issues/61) this adds the config/env variable for excluding disabled products from Magento import. Adds to `config/default.json` and `mage2vs.js`. 