### PR TITLE
Fixed code formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ You can run the following command to execute the full import:
  ```
 
  ... or in multistore setup You can run the same command with specified `store-code` parameter
-`
-``bash
+
+```bash
  yarn mage2vs import --store-code=de
  ```
  


### PR DESCRIPTION
There was an issue in the README causing the wrong text to be formatted as code near the end of the file. 