### PR TITLE
Do not use deprecated functions

### DIFF
--- a/src/lib/image.js
+++ b/src/lib/image.js
@@ -26,7 +26,11 @@ export async function resize (buffer, width, height) {
     const transformer = sharp(buffer);
 
     if (width || height) {
-      transformer.resize(width, height).max().withoutEnlargement();
+      const options = {
+        withoutEnlargement: true,
+        fit: sharp.fit.inside
+      }
+      transformer.resize(width, height, options)
     }
 
     return transformer.toBuffer();


### PR DESCRIPTION
This PR removes the following warning messages which are displayed when resizing an image from the api:

> DeprecationWarning: max() is deprecated, use resize({ fit: "inside" }) instead
> DeprecationWarning: withoutEnlargement() is deprecated, use resize({ withoutEnlargement: true }) instead