### PR TITLE
Changed apiVersion from hardcoded value to config value

### DIFF
--- a/src/platform/magento1/tax.js
+++ b/src/platform/magento1/tax.js
@@ -67,7 +67,7 @@ class TaxProxy extends AbstractTaxProxy {
             port: this._config.elasticsearch.port
           },
           log: 'debug',
-          apiVersion: '5.5',
+          apiVersion: this._config.elasticsearch.apiVersion,
           requestTimeout: 5000
         }
         if (this._config.elasticsearch.user) {


### PR DESCRIPTION
The value 5.5 was hardcoded into the source code but the value from
this._config.elasticsearch.apiVersion should be used when creating the
elasticsearch client.