### PR TITLE
Add missing parameters to processor adapters

### DIFF
--- a/src/graphql/elasticsearch/catalog/processor.js
+++ b/src/graphql/elasticsearch/catalog/processor.js
@@ -1,13 +1,13 @@
 import config from 'config'
 import ProcessorFactory from '../../../processor/factory'
 
-export default function esResultsProcessor(response, entityType, indexName) {
+export default function esResultsProcessor(response, entityType, indexName, req, res) {
   return new Promise((resolve, reject) => {
     const factory = new ProcessorFactory(config)
-    let resultProcessor = factory.getAdapter(entityType, indexName)
+    let resultProcessor = factory.getAdapter(entityType, indexName, req, res)
 
     if (!resultProcessor) {
-      resultProcessor = factory.getAdapter('default', indexName) // get the default processor
+      resultProcessor = factory.getAdapter('default', indexName, req, res) // get the default processor
     }
 
     resultProcessor.process(response.hits.hits)

--- a/src/graphql/elasticsearch/catalog/resolver.js
+++ b/src/graphql/elasticsearch/catalog/resolver.js
@@ -12,6 +12,8 @@ const resolver = {
 };
 
 async function list(filter, sort, currentPage, pageSize, search, context, rootValue, _sourceInclude, _sourceExclude) {
+  const { req, res } = context;
+
   let query = buildQuery({
     filter: filter,
     sort: sort,
@@ -21,7 +23,7 @@ async function list(filter, sort, currentPage, pageSize, search, context, rootVa
     type: 'product'
   });
 
-  let esIndex  = getIndexName(context.req.url)
+  let esIndex  = getIndexName(req.url)
 
   let esResponse = await client.search({
     index: esIndex,
@@ -33,7 +35,7 @@ async function list(filter, sort, currentPage, pageSize, search, context, rootVa
 
   if (esResponse && esResponse.hits && esResponse.hits.hits) {
     // process response result (caluclate taxes etc...)
-    esResponse.hits.hits = await esResultsProcessor(esResponse, config.elasticsearch.indexTypes[0], esIndex);
+    esResponse.hits.hits = await esResultsProcessor(esResponse, config.elasticsearch.indexTypes[0], esIndex, req, res);
   }
 
   let response = {}

--- a/src/processor/product.js
+++ b/src/processor/product.js
@@ -4,12 +4,12 @@ const hmac = jwa('HS256');
 import { sgnSrc } from '../lib/util'
 
 class ProductProcessor {
-  constructor(config, entityType, indexName, req, res){
+  constructor(config, entityType, indexName, req, res) {
     this._config = config
     this._entityType = entityType
     this._indexName = indexName
     this._req = req
-    this._res = res    
+    this._res = res
   }
 
   process (items, groupId = null) {
@@ -49,7 +49,7 @@ class ProductProcessor {
               return subItem
             })
           }
-          
+
           return item
         }).bind(this))
 


### PR DESCRIPTION
The GraphQL endpoint is not setting the required `req` and `res` parameters in the processor adapter so queries to the `products` query are throwing the following error:

```
Entering ProductProcessor::process
Taxes will be calculated for GB  false
Elasticsearch INFO: 2019-04-17T18:25:22Z
  Adding connection to http://localhost:9200/

Elasticsearch DEBUG: 2019-04-17T18:25:22Z
  starting request {
    "method": "POST",
    "path": "/vue_storefront_magento_1/taxrule/_search",
    "body": {},
    "query": {}
  }


Elasticsearch DEBUG: 2019-04-17T18:25:22Z
  Request complete

TypeError: Cannot read property 'query' of undefined
    at ProductProcessor.<anonymous> (/Users/jahvi/Repositories/vue-storefront-api/src/processor/product.js:33:21)