### PR TITLE
#235(mage2vs) feat: add import of cms blocks and pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.1] - 2019.05.08
+- Added import of magento 2 cms pages and blocks to the full import - @toh82 (#235)
+- Added information about magento 2 cms pages and blocks import to the readme - @toh82 (#235)
+
 ## [1.10.0-rc.1] - UNRELEASED
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ You can run the following command to execute the full import:
 ```bash
  yarn mage2vs import --store-code=de
  ```
+
+ Import of CMS blocks and pages is also performed by the full import. If the CMS API extension ((SnowdogApps/magento2-cms-api)[https://github.com/SnowdogApps/magento2-cms-api]) was not installed in magento 2, it's recommended to skip the CMS import commands.
+
+```bash
+ yarn mage2vs import --skip-blocks --skip-pages
+ ```
  
 ## Executing delta indexer
 


### PR DESCRIPTION
Since in the mage2vuestorefront adapter an error is thrown if something goes wrong my idea was to catch it here and display a proper message