### PR TITLE
Fix o2m order schema parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.2] - 2019.05.20
+- Fix failing o2m when parsing order schema - @lukeromanowicz (#248)
+
 ## [1.9.1] - 2019.05.10
 - Mount ElasticSearch data to `docker/elasticsearch/data` directory - @dimasch, @lukeromanowicz (#237, #241)
 - Fix product schema and importer in migration process - @lukeromanowicz (#239)

--- a/src/models/order.schema.js
+++ b/src/models/order.schema.js
@@ -1,4 +1,4 @@
-export default {
+exports.default = {
   additionalProperties: false,
   required: [
     'products',


### PR DESCRIPTION
Fix `error: uncaughtException: Unexpected token export` when running o2m