### PR TITLE
introduce orderNumber to order creation endpoint

### DIFF
--- a/src/platform/magento2/o2m.js
+++ b/src/platform/magento2/o2m.js
@@ -233,7 +233,7 @@ function processSingleOrder(orderData, config, job, done, logger = console) {
                 redisClient.set("order$$totals$$" + orderData.order_id, JSON.stringify(result[1]));
 
                 if(job) job.progress(currentStep++, TOTAL_STEPS);
-                return done(null, { magentoOrderId: result, backendOrderId: result, transferedAt: new Date() });
+                return done(null, { magentoOrderId: result, orderNumber: orderData.increment_id, backendOrderId: result, transferedAt: new Date() });
               }).catch(err => {
                 logger.error('Error placing an order', err, typeof err)
                 if (job) job.attempts(6).backoff({ delay: 30*1000, type:'fixed' }).save()


### PR DESCRIPTION
As its common to show customers an OrderNumber which is in no relation to the ID used for the Order Entity, it makes sense to introduce this in a platform agnostic way.

Magento for example uses the increment_id for the order number. It will likely be named different for other systems.

To prevent BC breaks in the future, the name should be carefully thought out.

Currently the recent solution for the MyOrder Page is relying on the existence of increment_id, which may not exist for other Systems.

related issue:
https://github.com/DivanteLtd/vue-storefront/issues/2743



Follow Up changes:

- if this value gets added here, it next needs to be added to the ThankYouPage
- The MyOrder Page needs to be aligned in usage of this value.
  - needs maybe change on API side?
  - should implement a fallback for systems, which dont have a dedicated OrderNumber?



I left the magentoOrderId unchanged, as Iam not sure about its usage and did not want to provoke a BC break.