### PR TITLE
Use Redis Auth when provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added import of magento 2 cms pages and blocks to the full import - @toh82 (#235)
 - Added information about magento 2 cms pages and blocks import to the readme - @toh82 (#235)
 - introduce orderNumber to order creation endpoint - @Flyingmana (#251)
+- Added optional Redis Auth functionality. @rain2o (#@todo)
 
 ### Fixed
 - Missing `res` and `req` parameters are now passed to ProductProcessor - @jahvi (#218)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added import of magento 2 cms pages and blocks to the full import - @toh82 (#235)
 - Added information about magento 2 cms pages and blocks import to the readme - @toh82 (#235)
 - introduce orderNumber to order creation endpoint - @Flyingmana (#251)
-- Added optional Redis Auth functionality. @rain2o (#@todo)
+- Added optional Redis Auth functionality. @rain2o (#267)
 
 ### Fixed
 - Missing `res` and `req` parameters are now passed to ProductProcessor - @jahvi (#218)

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -10,6 +10,7 @@
   "redis": {
     "host": "REDIS_HOST",
     "port": "REDIS_PORT",
-    "db": "REDIS_DB"
+    "db": "REDIS_DB",
+    "auth": "REDIS_AUTH"
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -35,7 +35,8 @@
   "redis": {
     "host": "localhost",
     "port": 6379,
-    "db": 0
+    "db": 0,
+    "auth": false
   },
   "kue": {},
   "availableStores": [

--- a/scripts/kue.js
+++ b/scripts/kue.js
@@ -8,11 +8,7 @@ program
   .option('-q|--prefix <prefix>', 'prefix', 'q')
   .action((cmd) => {
     kue.createQueue({
-      redis: {
-        host: config.host,
-        port: config.port,
-        db: config.db
-      },
+      redis: config,
       prefix: cmd.prefix
     })
   

--- a/scripts/mage2vs.js
+++ b/scripts/mage2vs.js
@@ -40,6 +40,7 @@ function getMagentoDefaultConfig(storeCode) {
     REDIS_HOST: config.redis.host,
     REDIS_PORT: config.redis.port,
     REDIS_DB: config.redis.db,
+    REDIS_AUTH: config.redis.auth,
     INDEX_NAME: config.elasticsearch.indices[0],
     DATABASE_URL: `${config.elasticsearch.protocol}://${config.elasticsearch.host}:${config.elasticsearch.port}`
   }

--- a/src/api/sync.js
+++ b/src/api/sync.js
@@ -15,6 +15,9 @@ export default ({ config, db }) => {
 		redisClient.on('error', function (err) { // workaround for https://github.com/NodeRedis/node_redis/issues/713
 			redisClient = Redis.createClient(config.redis); // redis client
 		});
+		if (config.redis.auth) {
+			redisClient.auth(config.redis.auth);
+		}
 		
 		redisClient.get('order$$id$$' + req.param('order_id'), function (err, reply) {
 			const orderMetaData = JSON.parse(reply)

--- a/src/platform/magento2/o2m.js
+++ b/src/platform/magento2/o2m.js
@@ -8,6 +8,9 @@ let redisClient = Redis.createClient(config.redis); // redis client
 redisClient.on('error', function (err) { // workaround for https://github.com/NodeRedis/node_redis/issues/713
   redisClient = Redis.createClient(config.redis); // redis client
 });
+if (config.redis.auth) {
+  redisClient.auth(config.redis.auth);
+}
 const countryMapper = require('../../lib/countrymapper')
 const Ajv = require('ajv'); // json validator
 const fs = require('fs');


### PR DESCRIPTION
Closes #267 

With this update all areas in this repo that connect with Redis now use the optional `redis.auth` value if it's available. To use it you simply need to set the env variable `REDIS_AUTH` to the appropriate password. If you don't set this variable it will default to `false` and will not be used.