### PR TITLE
Fix command yarn dev:inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - introduce orderNumber to order creation endpoint - @Flyingmana (#251)
 - Added optional Redis Auth functionality. @rain2o (#267)
 - Extensions have ability to modify Elasticsearch results. @grimasod (#269)
-- Fix `yarn dev:inspect` command and extract nodemon config to nodemon.json @Tjitse-E (#272)
 
 ### Fixed
 - Missing `res` and `req` parameters are now passed to ProductProcessor - @jahvi (#218)
@@ -22,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed moving of schema files to the dist folder @ResuBaka (#244)
 - fixed missing assetPath config for magento1  @ResuBaka (#245)
 - fixed new payload for magento1 stock check endpoint (#261)
+- Fix `yarn dev:inspect` command and extract nodemon config to nodemon.json @Tjitse-E (#272)
 
 ## [1.9.4] - 2019.06.03
 - Extension schemas in `src/models` are not required anymore - @EmilsM, @lukeromanowicz (#259, #263)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - introduce orderNumber to order creation endpoint - @Flyingmana (#251)
 - Added optional Redis Auth functionality. @rain2o (#267)
 - Extensions have ability to modify Elasticsearch results. @grimasod (#269)
+- Remove `yarn dev:inspect` command and add `yarn debug` instead. @Tjitse-E (#272)
 
 ### Fixed
 - Missing `res` and `req` parameters are now passed to ProductProcessor - @jahvi (#218)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - introduce orderNumber to order creation endpoint - @Flyingmana (#251)
 - Added optional Redis Auth functionality. @rain2o (#267)
 - Extensions have ability to modify Elasticsearch results. @grimasod (#269)
-- Remove `yarn dev:inspect` command and add `yarn debug` instead. @Tjitse-E (#272)
+- Fix `yarn dev:inspect` command and extract nodemon config to nodemon.json @Tjitse-E (#272)
 
 ### Fixed
 - Missing `res` and `req` parameters are now passed to ProductProcessor - @jahvi (#218)

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,8 @@
+{
+  "verbose": true,
+  "debug": false,
+  "exec": "ts-node src",
+  "watch": ["./src"],
+  "ext": "ts, js",
+  "inspect": true
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist",
   "scripts": {
     "dev": "nodemon -w src --exec \"ts-node src\"",
-    "dev:inspect": "nodemon -w src --exec \"ts-node --inspect src\"",
+    "debug": "node --inspect -r ts-node/register src",
     "build": "npm run -s build:code && npm run -s build:copy:graphql && npm run -s build:copy:schema",
     "build:code": "tsc --build",
     "build:copy:graphql": "cpx src/**/*.graphqls dist",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "description": "vue-storefront API and data services",
   "main": "dist",
   "scripts": {
-    "dev": "nodemon -w src --exec \"ts-node src\"",
-    "debug": "node --inspect -r ts-node/register src",
+    "dev": "nodemon",
+    "dev:inspect": "nodemon --exec \"node --inspect -r ts-node/register src\"",
     "build": "npm run -s build:code && npm run -s build:copy:graphql && npm run -s build:copy:schema",
     "build:code": "tsc --build",
     "build:copy:graphql": "cpx src/**/*.graphqls dist",


### PR DESCRIPTION
Fixes #271 

~~I have tried triggering the debugger ont he latest develop branch (with `nodemon`/typescript), but this doesn't work. With the `node` command, however, it does work. Only we then lose the hot reloading feature of nodemon.. That's why i've renamed the command to `yarn debug`. In my opinion we can still change the name of this command, because the command `yarn dev:inspect` isn't yet in the latest release 1.9.4.~~

I have found a better solution in which we can keep nodemon and als use the --inspect flag. If we extract the nodemon config to a nodemon.json everything works as expected. We can then also clean up the `yarn dev` command, all the default settings are moved to nodemon.json. `yarn dev:inspect` also uses nodemon.json, but with a different `--exec` option, see package.json.

Output of `yarn dev:inspect`:
```
yarn run v1.15.2
$ nodemon --exec "node --inspect -r ts-node/register src"
[nodemon] 1.19.1
[nodemon] reading config ./nodemon.json
[nodemon] to restart at any time, enter `rs`
[nodemon] or send SIGHUP to 11026 to restart
[nodemon] watching: /Users/tjitse/sites/vue-storefront-api/src/**/*
[nodemon] watching extensions: ts,js
[nodemon] starting `node --inspect -r ts-node/register src`
[nodemon] spawning
[nodemon] child pid: 11028
Debugger listening on ws://127.0.0.1:9229/f810a054-4865-4c9b-bf92-eda26d3ef661
For help, see: https://nodejs.org/en/docs/inspector
[nodemon] watching 97 files
Debugger attached.
```

