### PR TITLE
Remove duplication fom Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,13 @@ install:
 
 jobs:
   include:
-    - stage: Build
+    - &build
+      stage: Build
       script:
-        - yarn lint
-        - yarn build
-      node_js: "8"
-    - script:
-        - yarn lint
-        - yarn build
-      node_js: "10"
+      - yarn lint
+      - yarn build
+      node_js: '10'
+
+    - <<: *build
+      node_js: '8'
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - introduce orderNumber to order creation endpoint - @Flyingmana (#251)
 - Added optional Redis Auth functionality. @rain2o (#267)
 - Extensions have ability to modify Elasticsearch results. @grimasod (#269)
+- Refactored Travis build config @Tjitse-E (#273)
 
 ### Fixed
 - Missing `res` and `req` parameters are now passed to ProductProcessor - @jahvi (#218)


### PR DESCRIPTION
I was looking at the current Travis config and I noticed that the build stage was there twice (one time fo each supported NodeJS version). Using the YAML anchor function we can remove that duplication. This will also lead to a smaller Travis config in the future, for example, if we want to support Node v12.