### PR TITLE
Fixed store specific API config/url in util.js

### DIFF
--- a/src/platform/magento1/util.js
+++ b/src/platform/magento1/util.js
@@ -1,8 +1,8 @@
 import config from 'config'
 /**
  * Adjust the config provided to the current store selected via request params
- * @param Object config configuration 
- * @param Express request req 
+ * @param Object config configuration
+ * @param Express request req
  */
 export function multiStoreConfig(apiConfig, req) {
     let confCopy = Object.assign({}, apiConfig)
@@ -17,16 +17,12 @@ export function multiStoreConfig(apiConfig, req) {
 
     if (storeCode && config.availableStores.indexOf(storeCode) >= 0)
     {
-        if (config.magento2['api_' + storeCode]) {
-            confCopy = Object.assign({}, config.magento2['api_' + storeCode]) // we're to use the specific api configuration - maybe even separate magento instance
-        }
-
-        if (config.platform === 'magento1') {
+        if (config.magento1['api_' + storeCode]) {
+            confCopy = Object.assign({}, config.magento1['api_' + storeCode]) // we're to use the specific api configuration - maybe even separate magento instance
+        } else {
             if (new RegExp("(/" + config.availableStores.join("|") + "/)", "gm").exec(confCopy.url) === null) {
                 confCopy.url = (confCopy.url).replace(/(vsbridge)/gm, `${storeCode}/$1`);
             }
-        } else {
-            confCopy.url = confCopy.url + '/' + storeCode
         }
     } else {
         if (storeCode) {


### PR DESCRIPTION
This does fix 3 things 

* Looking in the magento2 config for store api url
* changing the URL when a config value for magento1 for the store was found
* Adding the store code to the end of the url which is not working in the magento1 module