### PR TITLE
Include Magento Currency Code in mage2vs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed missing assetPath config for magento1  @ResuBaka (#245)
 - fixed new payload for magento1 stock check endpoint (#261)
 - Fix `yarn dev:inspect` command and extract nodemon config to nodemon.json @Tjitse-E (#272)
+- Include Magento Currency Code in mage2vs import and productsdelta if available @rain2o (#281)
 
 ## [1.9.4] - 2019.06.03
 - Extension schemas in `src/models` are not required anymore - @EmilsM, @lukeromanowicz (#259, #263)

--- a/scripts/mage2vs.js
+++ b/scripts/mage2vs.js
@@ -92,6 +92,9 @@ program
         magentoConfig.INDEX_META_PATH = '.lastIndex-' + cmd.storeCode + '.json'
         magentoConfig.MAGENTO_STORE_ID = storeView.storeId
         magentoConfig.MAGENTO_MSI_STOCK_ID = storeView.msi.stockId
+        if (storeView.i18n && storeView.i18n.currencyCode) {
+          magentoConfig.MAGENTO_CURRENCY_CODE = storeView.i18n.currencyCode;
+        }
       }
     }
 
@@ -136,6 +139,9 @@ program
       } else {
         magentoConfig.INDEX_NAME = storeView.elasticsearch.index;
         magentoConfig.MAGENTO_STORE_ID = storeView.storeId;
+        if (storeView.i18n && storeView.i18n.currencyCode) {
+          magentoConfig.MAGENTO_CURRENCY_CODE = storeView.i18n.currencyCode;
+        }
       }
     }
 


### PR DESCRIPTION
Closes #281 

When running `mage2vs import` and `productsdelta` the currency code is now passed to the config if it's available in `storeView.i18n.currencyCode`.