### PR TITLE
Feature add setting for mailchimp subscription status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.11.0-rc.1] - UNRELEASED
 
+### Added
+- Constant for Mailchimp subscription status
+
 ### Fixed
 - The `product.price_*` fields have been normalized with the backward compatibility support (see `config.tax.deprecatedPriceFieldsSupport` which is by default true) - @pkarw (#289)
 - The `product.final_price` field is now being taken into product price calcualtion. Moreover, we've added the `config.tax.finalPriceIncludesTax` - which is set to `true` by default. All the `price`, `original_price` and `special_price` fields are calculated accordingly. It was required as Magento2 uses `final_price` to set the catalog pricing rules after-prices - @pkarw (#289)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.11.0-rc.1] - UNRELEASED
 
 ### Added
-- Constant for Mailchimp subscription status
+- Constant for Mailchimp subscription status - @KonstantinSoelch (#294)
 
 ### Fixed
 - The `product.price_*` fields have been normalized with the backward compatibility support (see `config.tax.deprecatedPriceFieldsSupport` which is by default true) - @pkarw (#289)

--- a/config/default.json
+++ b/config/default.json
@@ -146,7 +146,8 @@
     "mailchimp": {
       "listId": "e06875a7e1",
       "apiKey": "a9a3318ea7d30f5c5596bd4a78ae0985-us3",
-      "apiUrl": "https://us3.api.mailchimp.com/3.0"
+      "apiUrl": "https://us3.api.mailchimp.com/3.0",
+      "userStatus": "subscribed"
     },
     "mailService": {
       "transport": {

--- a/src/api/extensions/mailchimp-subscribe/index.js
+++ b/src/api/extensions/mailchimp-subscribe/index.js
@@ -47,7 +47,7 @@ module.exports = ({ config, db }) => {
       method: 'POST',
       headers: { 'Authorization': 'apikey ' + config.extensions.mailchimp.apiKey },
       json: true,
-      body: { members: [ { email_address: userData.email, status: 'subscribed' } ], "update_existing": true }
+      body: { members: [ { email_address: userData.email, status: config.extensions.mailchimp.userStatus } ], "update_existing": true }
     }, function (error, response, body) {
       if (error) {
         console.error(error)


### PR DESCRIPTION
The default status was set to subscribed, but since GDPR needs an Opt-In pending would fit way better.

@lukeromanowicz i created a new PR, since i accidentally did a reformat of the code.
I've updated the changelog, please check if everything is alright.
