### PR TITLE
Disable unique url generation for categories import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Constant for Mailchimp subscription status - @KonstantinSoelch (#294)
+- mage2vs import now has optional `--generate-unique-url-keys` parameter which defaults to `false` to enable/disable the url key generation with name and id for categories - @rain2o (#232)
 
 ### Fixed
 - The `product.price_*` fields have been normalized with the backward compatibility support (see `config.tax.deprecatedPriceFieldsSupport` which is by default true) - @pkarw (#289)

--- a/scripts/mage2vs.js
+++ b/scripts/mage2vs.js
@@ -128,6 +128,7 @@ program
   .option('--skip-products <skipProducts>', 'skip import of products', false)
   .option('--skip-pages <skipPages>', 'skip import of cms pages', false)
   .option('--skip-blocks <skipBlocks>', 'skip import of cms blocks', false)
+  .option('--generate-unique-url-keys <generateUniqueUrlKeys>', 'generate unique url keys for categories', false)
   .action((cmd) => {
     let magentoConfig = getMagentoDefaultConfig(cmd.storeCode)
 
@@ -169,7 +170,9 @@ program
     if (cmd.skipBlocks) {
       magentoConfig.SKIP_BLOCKS = true;
     }
-
+    
+    magentoConfig.GENERATE_UNIQUE_URL_KEYS = cmd.generateUniqueUrlKeys;
+    
     const env = Object.assign({}, magentoConfig, process.env)  // use process env as well
     console.log('=== The mage2vuestorefront full reindex is about to start. Using the following Magento2 config ===', magentoConfig)
 
@@ -209,7 +212,8 @@ program
           'node_modules/mage2vuestorefront/src/cli.js',
           'categories',
           '--removeNonExistent=true',
-          '--extendedCategories=true'
+          '--extendedCategories=true',
+          `--generateUniqueUrlKeys=${magentoConfig.GENERATE_UNIQUE_URL_KEYS}`
         ], { env: env, shell: true })
       }
     }


### PR DESCRIPTION
Closes #232 . Adds optional parameter `--generate-unique-url-keys` to the `mage2vs import` command. It defaults to `false`. This is passed along to the `mage2vuestorefront` scripts to tell it if it should generate unique url keys for categories or not.