### PR TITLE
#312 upgrade graphql version to v0.13+

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "elasticsearch": "^15.2.0",
     "email-check": "^1.1.0",
     "express": "^4.16.3",
-    "graphql": "^0.10.1",
+    "graphql": "^0.13.1",
     "graphql-tools": "^1.2.1",
     "humps": "^1.1.0",
     "jsonfile": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2596,12 +2596,12 @@ graphql-tools@^1.2.1:
   optionalDependencies:
     "@types/graphql" "^0.9.0"
 
-graphql@^0.10.1:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.5.tgz#c9be17ca2bdfdbd134077ffd9bbaa48b8becd298"
-  integrity sha512-Q7cx22DiLhwHsEfUnUip1Ww/Vfx7FS0w6+iHItNuN61+XpegHSa3k5U0+6M5BcpavQImBwFiy0z3uYwY7cXMLQ==
+graphql@^0.13.1:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
+  integrity sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==
   dependencies:
-    iterall "^1.1.0"
+    iterall "^1.2.1"
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -3119,7 +3119,7 @@ isstream@0.1.x, isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-iterall@^1.1.0:
+iterall@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
   integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==


### PR DESCRIPTION
As per [#312](https://github.com/DivanteLtd/vue-storefront-api/issues/312).

* Upgraded `package.json` graphql version

* Upgraded updated `yarn.lock` file