### PR TITLE
Done: Remove index value not_analyzed for some fields as it is deprecated #334

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Sharp dependency has been updated. *It might require reinstalling yarn dependencies* - @lukeromanowicz
+- Replaced index property value `not_analyzed` with `true` for `options` field in attribute schema - @adityasharma7 (#334)
 
 ### Fixed
 - Missing `res` and `req` parameters are now passed to ProductProcessor - @jahvi (#218)

--- a/config/elastic.schema.attribute.json
+++ b/config/elastic.schema.attribute.json
@@ -10,7 +10,7 @@
             "properties": {
                 "value": {
                     "type": "text",
-                    "index": "not_analyzed"
+                    "index": true
                 }
             }
         }


### PR DESCRIPTION

As of 5.0 value not_analyzed is no longer applicable.
Reference: https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_mapping_changes.html#_literal_index_literal_property
Citation: On all field datatypes (except for the deprecated string field), the index property now only accepts true/false instead of not_analyzed/no. The string field still accepts analyzed/not_analyzed/no.
As per https://www.elastic.co/guide/en/elasticsearch/reference/1.4/mapping-core-types.html, not_analyzed means that its still searchable, but does not go through any analysis process or broken down into tokens.
As per https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html, index means Should the field be searchable? Accepts true (default) or false.

So, changing index value not_analyzed to true. We can also remove index key as default value is true, but as I am unsure how it works when migrating to new release with schema changes. Setting it true as it may cause no harm and produces desired results

closes #334