### PR TITLE
Adding new reviews - get status from configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ NOTE: `npm` users will still have to install the dependencies individually in th
 
 ## Reviews
 To use review feature you need to install custom module for Magento 2: [Divante ReviewApi](https://github.com/DivanteLtd/magento2-review-api)
+By default new reviews will be added with status "Pending". 
+```json
+  "review": {
+    "defaultReviewStatus": 2 
+  },
+```
 
 ## Output Cache
 Vue Storefront API supports output cache for catalog operations. Cache is tagged and can by dynamically invalidated. Please find the details how to configure it [in our docs](https://docs.vuestorefront.io/guide/basics/ssr-cache.html).

--- a/config/default.json
+++ b/config/default.json
@@ -147,6 +147,9 @@
     "userGroupId": null,
     "useOnlyDefaultUserGroupId": false
   },
+  "review": {
+    "defaultReviewStatus": 2 
+  },
   "bodyLimit": "100kb",
   "corsHeaders": [
     "Link"

--- a/src/api/review.js
+++ b/src/api/review.js
@@ -18,6 +18,8 @@ export default ({config, db}) => {
     const reviewSchema = require('../models/review.schema')
     const validate = ajv.compile(reviewSchema)
 
+    req.body.review.review_status = config.review.defaultReviewStatus
+
     if (!validate(req.body)) {
       console.dir(validate.errors);
       apiStatus(res, validate.errors, 500);


### PR DESCRIPTION
Fix review_status field vulnerability  https://github.com/DivanteLtd/magento2-review-api/issues/17
Set review status in configuration. 
Related PR to VSF:
https://github.com/DivanteLtd/vue-storefront/pull/3546