### PR TITLE
Order History Pagination

### DIFF
--- a/src/api/user.js
+++ b/src/api/user.js
@@ -149,7 +149,11 @@ export default ({config, db}) => {
    */
   userApi.get('/order-history', (req, res) => {
     const userProxy = _getProxy(req)
-    userProxy.orderHistory(req.query.token).then((result) => {
+    userProxy.orderHistory(
+			req.query.token,
+			req.query.pageSize || 20,
+			req.query.currentPage || 1
+		).then((result) => {
       apiStatus(res, result, 200);
     }).catch(err => {
       apiError(res, err);

--- a/src/platform/magento2/user.js
+++ b/src/platform/magento2/user.js
@@ -21,8 +21,8 @@ class UserProxy extends AbstractUserProxy {
 
     return this.api.customers.me(requestToken)
   }
-  orderHistory (requestToken) {
-    return this.api.customers.orderHistory(requestToken)
+  orderHistory (requestToken, pageSize = 20, currentPage = 1) { 
+    return this.api.customers.orderHistory(requestToken, pageSize, currentPage)
   }
   resetPassword (emailData) {
     return this.api.customers.resetPassword(emailData)


### PR DESCRIPTION
In support of [magento2-rest-client#3](https://github.com/DivanteLtd/magento2-rest-client/issues/3) and PR [magento2-rest-client#19](https://github.com/DivanteLtd/magento2-rest-client/pull/19).

Adds optional ability to paginate order history with the default values of 20 items and page 1.