### PR TITLE
Fix/graphql resolvers and schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0-rc.2] - unreleased
+
+### Fixed
+
+- Fixed some smaller issues with graphql so that it is now working again with the fronted - #350
+
+
 ## [1.11.0-rc.1] - 2019.10.03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "config": "^1.30.0",
     "cors": "^2.8.4",
     "elasticdump": "^3.3.12",
-    "elasticsearch": "^15.2.0",
+    "@elastic/elasticsearch": "5.6.*",
     "email-check": "^1.1.0",
     "express": "^4.16.3",
     "fs-extra": "^8.1.0",

--- a/src/graphql/elasticsearch/attribute/resolver.js
+++ b/src/graphql/elasticsearch/attribute/resolver.js
@@ -3,21 +3,21 @@ import client from '../client';
 import { buildQuery } from '../queryBuilder';
 import { getIndexName } from '../mapping'
 
-async function listAttributes (attributes, context, rootValue, _sourceInclude) {
+async function listAttributes (attributes, context, rootValue, _source_include) {
   let query = buildQuery({ filter: attributes, pageSize: 150, type: 'attribute' });
 
-  if (_sourceInclude === undefined) {
-    _sourceInclude = config.entities.attribute.includeFields
+  if (_source_include === undefined) {
+    _source_include = config.entities.attribute.includeFields
   }
 
   const response = await client.search({
     index: getIndexName(context.req.url),
     type: config.elasticsearch.indexTypes[3],
     body: query,
-    _sourceInclude
+    _source_include
   });
 
-  return response;
+  return response.body;
 }
 
 const resolver = {

--- a/src/graphql/elasticsearch/attribute/resolver.js
+++ b/src/graphql/elasticsearch/attribute/resolver.js
@@ -6,7 +6,7 @@ import { getIndexName } from '../mapping'
 async function listAttributes (attributes, context, rootValue, _source_include) {
   let query = buildQuery({ filter: attributes, pageSize: 150, type: 'attribute' });
 
-  if (_source_include === undefined) {
+  if (!_source_include) {
     _source_include = config.entities.attribute.includeFields
   }
 

--- a/src/graphql/elasticsearch/catalog/schema.graphqls
+++ b/src/graphql/elasticsearch/catalog/schema.graphqls
@@ -41,7 +41,7 @@ input FilterTypeInput @doc(description: "FilterTypeInput specifies which action 
     gte: String @doc(description: "Greater than or equal to")
     gteq: String @doc(description: "Greater than or equal to")
     in: [JSON] @doc(description: "In. The value can contain a set of comma-separated values")
-    like: String @doc(description: "Like. The specified value can contain % (percent signs) to allow matching of 0 or more characters")
+    like: [String] @doc(description: "Like. The specified value can contain % (percent signs) to allow matching of 0 or more characters")
     lt: String @doc(description: "Less than")
     lte: String @doc(description: "Less than or equal to")
     lteq: String @doc(description: "Less than or equal to")
@@ -151,6 +151,7 @@ input ProductFilterInput @doc(description: "ProductFilterInput defines the filte
     stock: ProductFilterInput @doc(description: "The product stock. Customers use this stock to identify the product.")
     is_in_stock: FilterTypeInput @doc(description: "Is product in stock")
     keyword: FilterTypeInput @doc(description: "keyword filter input")
+    url_path: FilterTypeInput @doc(description: "The url path assigned to the product")
 }
 
 type LayerFilter {

--- a/src/graphql/elasticsearch/category/resolver.js
+++ b/src/graphql/elasticsearch/category/resolver.js
@@ -6,7 +6,7 @@ import { getIndexName } from '../mapping'
 async function list (search, filter, currentPage, pageSize = 200, sort, context, rootValue, _source_include) {
   let query = buildQuery({ search, filter, currentPage, pageSize, sort, type: 'category' });
 
-  if (_source_include === undefined) {
+  if (!_source_include) {
     _source_include = config.entities.category.includeFields
   }
 

--- a/src/graphql/elasticsearch/category/resolver.js
+++ b/src/graphql/elasticsearch/category/resolver.js
@@ -3,18 +3,18 @@ import client from '../client';
 import { buildQuery } from '../queryBuilder';
 import { getIndexName } from '../mapping'
 
-async function list (search, filter, currentPage, pageSize = 200, sort, context, rootValue, _sourceInclude) {
+async function list (search, filter, currentPage, pageSize = 200, sort, context, rootValue, _source_include) {
   let query = buildQuery({ search, filter, currentPage, pageSize, sort, type: 'category' });
 
-  if (_sourceInclude === undefined) {
-    _sourceInclude = config.entities.category.includeFields
+  if (_source_include === undefined) {
+    _source_include = config.entities.category.includeFields
   }
 
   const response = await client.search({
     index: getIndexName(context.req.url),
     type: config.elasticsearch.indexTypes[1],
     body: query,
-    _sourceInclude
+    _source_include
   });
 
   return response;

--- a/src/graphql/elasticsearch/category/schema.graphqls
+++ b/src/graphql/elasticsearch/category/schema.graphqls
@@ -59,4 +59,5 @@ input CategorySortInput {
     display_mode: SortEnum @doc(description: "Category display mode")
     is_anchor: SortEnum @doc(description: "Is filter avalaible in category")
     page_layout: SortEnum @doc(description: "Category page layout")
+    _score: SortEnum @doc(description: "Category page layout")
 }

--- a/src/graphql/elasticsearch/client.js
+++ b/src/graphql/elasticsearch/client.js
@@ -1,12 +1,8 @@
 import config from 'config';
-import elasticsearch from 'elasticsearch';
+import elasticsearch from '@elastic/elasticsearch';
 
 const client = new elasticsearch.Client({
-  host: {
-    host: config.elasticsearch.host,
-    port: config.elasticsearch.port,
-    protocol: config.elasticsearch.protocol
-  }
+  node: `${config.elasticsearch.protocol}://${config.elasticsearch.host}:${config.elasticsearch.port}`
 });
 
 export default client;

--- a/src/graphql/elasticsearch/cms/resolver.js
+++ b/src/graphql/elasticsearch/cms/resolver.js
@@ -2,16 +2,16 @@ import config from 'config';
 import client from '../client';
 import { buildQuery } from '../queryBuilder';
 
-async function list (filter, currentPage, pageSize = 200, _sourceInclude, type) {
-  let query = buildQuery({ filter, currentPage, pageSize, _sourceInclude, type });
+async function list (filter, currentPage, pageSize = 200, _source_include, type) {
+  let query = buildQuery({ filter, currentPage, pageSize, _source_include, type });
 
   const response = await client.search({
     index: config.elasticsearch.indices[0],
     body: query,
     type,
-    _sourceInclude
+    _source_include
   });
-  const items = buildItems(response)
+  const items = buildItems(response.body)
 
   return items;
 }

--- a/src/graphql/elasticsearch/cms/schema.graphqls
+++ b/src/graphql/elasticsearch/cms/schema.graphqls
@@ -17,6 +17,7 @@ input CmsInput @doc(description: "ProductFilterInput defines the filters to be u
     id: FilterTypeInput @doc(description: "Id of the CMS entity")
     identifier: FilterTypeInput @doc(description: "Identifiers of the CMS entity")
     store_id: FilterTypeInput @doc(description: "Store Id of the CMS entity")
+    url_path: FilterTypeInput @doc(description: "The url path assigned to the cms_page")
 }
 
 type CmsPage @doc(description: "CMS pages information") {
@@ -32,6 +33,7 @@ type CmsPages @doc(description: "CMS page defines all CMS page information") {
     meta_description: String @doc(description: "CMS page meta description")
     meta_keywords: String @doc(description: "CMS page meta keywords")
     store_id: Int @doc(description: "Store Id of CMS page")
+    url_path: String @doc(description: "CMS page meta keywords")
 }
 
 type CmsBlocks @doc(description: "CMS blocks information") {
@@ -40,6 +42,7 @@ type CmsBlocks @doc(description: "CMS blocks information") {
 
 type CmsBlock @doc(description: "CMS block defines all CMS block information") {
     identifier: String @doc(description: "CMS block identifier")
+    id: Int @doc(description: "CMS block identifier")
     title: String @doc(description: "CMS block title")
     content: String @doc(description: "CMS block content")
     creation_time: String @doc(description: "Timestamp indicating when the CMS block was created")

--- a/src/graphql/elasticsearch/queryBuilder.js
+++ b/src/graphql/elasticsearch/queryBuilder.js
@@ -18,6 +18,16 @@ function processNestedFieldFilter (attribute, value) {
   return processedFilter;
 }
 
+/**
+ *
+ * @param {Object} object
+ * @param {String} scope
+ * @returns {boolean}
+ */
+function checkIfObjectHasScope ({ object, scope }) {
+  return object.scope === scope || (Array.isArray(object.scope) && object.scope.find(scrope => scrope === scope));
+}
+
 function applyFilters (filter, query, type) {
   if (filter.length === 0) {
     return query
@@ -46,7 +56,7 @@ function applyFilters (filter, query, type) {
 
     // apply default filters
     appliedFilters.forEach((filter) => {
-      if (filter.scope === 'default' && Object.keys(filter.value).length) {
+      if (checkIfObjectHasScope({ object: filter, scope: 'default' }) && Object.keys(filter.value).length) {
         if (rangeOperators.every(rangeOperator => Object.prototype.hasOwnProperty.call(filter.value, rangeOperator))) {
           // process range filters
           query = query.filter('range', filter.attribute, filter.value);
@@ -67,7 +77,7 @@ function applyFilters (filter, query, type) {
     let attrFilterBuilder = (filterQr, attrPostfix = '') => {
       appliedFilters.forEach((catalogfilter) => {
         const valueKeys = Object.keys(catalogfilter.value);
-        if (catalogfilter.scope === 'catalog' && valueKeys.length) {
+        if (checkIfObjectHasScope({ object: catalogfilter, scope: 'catalog' }) && valueKeys.length) {
           const isRange = valueKeys.filter(value => rangeOperators.indexOf(value) !== -1)
           if (isRange.length) {
             let rangeAttribute = catalogfilter.attribute

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,6 +139,18 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@elastic/elasticsearch@5.6.*":
+  version "5.6.20"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-5.6.20.tgz#990354700c3e3fbdae6cb1c62c2ba14b631af8dc"
+  integrity sha512-dOybHGWMo6J/rx/ad9IbROKYq5aQIOd0RrickbqrIU7pjg0J3qSIL4SN027jz1vdrtOcap7yovA+HUplrEXOog==
+  dependencies:
+    debug "^4.1.1"
+    decompress-response "^4.2.0"
+    into-stream "^5.1.0"
+    ms "^2.1.1"
+    once "^1.4.0"
+    pump "^3.0.0"
+
 "@google-cloud/common@^2.0.0":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@google-cloud/common/-/common-2.0.4.tgz#2b2001783e94fe903484f2673a2ff79e0685da81"
@@ -1890,6 +1902,13 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
+decompress-response@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
+  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
+  dependencies:
+    mimic-response "^2.0.0"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -2795,6 +2814,14 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
+from2@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  integrity sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+
 fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
@@ -3353,6 +3380,14 @@ interpret@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
+
+into-stream@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-5.1.1.tgz#f9a20a348a11f3c13face22763f2d02e127f4db8"
+  integrity sha512-krrAJ7McQxGGmvaYbB7Q1mcA+cRwg9Ij2RfWIeVesNBgVDZmzY/Fa4IpZUT3bmdRzMzdf/mzltCG2Dq99IZGBA==
+  dependencies:
+    from2 "^2.3.0"
+    p-is-promise "^3.0.0"
 
 invariant@^2.2.4:
   version "2.2.4"
@@ -4834,6 +4869,11 @@ mimic-response@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
+mimic-response@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.0.0.tgz#996a51c60adf12cb8a87d7fb8ef24c2f3d5ebb46"
+  integrity sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ==
+
 minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -5376,6 +5416,11 @@ p-is-promise@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
   integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
+
+p-is-promise@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-3.0.0.tgz#58e78c7dfe2e163cf2a04ff869e7c1dba64a5971"
+  integrity sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==
 
 p-limit@^1.1.0:
   version "1.3.0"


### PR DESCRIPTION
Here we had multible problems.

1. One was that some the like filter did not allow for multible strings as parameter.  
2. You could not filter/search for url_path of products
3. cms_blocks did not return the id so cms_blocks where not working in the frontend.
4. _source_include or  _source_exclude did not work anymore. This I have fixed with using the newer elasticsearch libary for es5


I have not tested it with the default theme and default data from the api but with our data it works fine. 