### PR TITLE
Bugfix for `fs.existsSync` path in API endpoints for schema extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `product.final_price` field is now being taken into product price calcualtion. Moreover, we've added the `config.tax.finalPriceIncludesTax` - which is set to `true` by default. All the `price`, `original_price` and `special_price` fields are calculated accordingly. It was required as Magento2 uses `final_price` to set the catalog pricing rules after-prices - @pkarw (#289)
 - Force ES connections to use protocol config option - @cewald (#303, #304)
 - Better handling of HTTP error codes provided by API client - #3151
+- Bugfix for `fs.existsSync` path in API endpoints for schema extensions (#363)
 
 ### Changed
 - Error responses for mailchimp - @andrzejewsky (#3337)

--- a/src/api/order.js
+++ b/src/api/order.js
@@ -29,7 +29,7 @@ export default ({ config, db }) => resource({
 
     const orderSchema = require('../models/order.schema.js')
     let orderSchemaExtension = {}
-    if (fs.existsSync('../models/order.schema.extension.json')) {
+    if (fs.existsSync('src/models/order.schema.extension.json')) {
       orderSchemaExtension = require('../models/order.schema.extension.json')
     }
     const validate = ajv.compile(merge(orderSchema, orderSchemaExtension));

--- a/src/api/user.js
+++ b/src/api/user.js
@@ -36,7 +36,7 @@ export default ({config, db}) => {
     const ajv = new Ajv();
     const userRegisterSchema = require('../models/userRegister.schema.json')
     let userRegisterSchemaExtension = {};
-    if (fs.existsSync('../models/userRegister.schema.extension.json')) {
+    if (fs.existsSync('src/models/userRegister.schema.extension.json')) {
       userRegisterSchemaExtension = require('../models/userRegister.schema.extension.json');
     }
     const validate = ajv.compile(merge(userRegisterSchema, userRegisterSchemaExtension))
@@ -150,10 +150,10 @@ export default ({config, db}) => {
   userApi.get('/order-history', (req, res) => {
     const userProxy = _getProxy(req)
     userProxy.orderHistory(
-			req.query.token,
-			req.query.pageSize || 20,
-			req.query.currentPage || 1
-		).then((result) => {
+      req.query.token,
+      req.query.pageSize || 20,
+      req.query.currentPage || 1
+    ).then((result) => {
       apiStatus(res, result, 200);
     }).catch(err => {
       apiError(res, err);
@@ -167,7 +167,7 @@ export default ({config, db}) => {
     const ajv = new Ajv();
     const userProfileSchema = require('../models/userProfile.schema.json')
     let userProfileSchemaExtension = {};
-    if (fs.existsSync('../models/userProfile.schema.extension.json')) {
+    if (fs.existsSync('src/models/userProfile.schema.extension.json')) {
       userProfileSchemaExtension = require('../models/userProfile.schema.extension.json');
     }
     const validate = ajv.compile(merge(userProfileSchema, userProfileSchemaExtension))


### PR DESCRIPTION
The `fs.existsSync` method is using the wrong paths for checking the JVS schema extensions.
This leads to the problem that they are never used.

I made the path relative to the current work directory and it is working again.