### PR TITLE
 Fixes for calculating lowest price after refactoring.

### DIFF
--- a/src/lib/taxcalc.js
+++ b/src/lib/taxcalc.js
@@ -72,6 +72,7 @@ export function updateProductPrices ({ product, rate, sourcePriceInclTax = false
     product.hasOwnProperty('original_final_price') &&
     product.hasOwnProperty('original_special_price')
   )
+
   // build objects with original price and tax
   // for first calculation use `price`, for next one use `original_price`
   const priceWithTax = createSinglePrice(parseFloat(product.original_price || product.price), rate_factor, sourcePriceInclTax && !hasOriginalPrices)
@@ -81,24 +82,30 @@ export function updateProductPrices ({ product, rate, sourcePriceInclTax = false
   // save original prices
   if (!hasOriginalPrices) {
     assignPrice({product, target: 'original_price', ...priceWithTax, deprecatedPriceFieldsSupport})
-
-    product.original_final_price = finalPriceWithTax.price
-    product.original_special_price = specialPriceWithTax.price
+    if (specialPriceWithTax.price) {
+      product.original_special_price = specialPriceWithTax.price
+    }
+    if (finalPriceWithTax.price) {
+      product.original_final_price = finalPriceWithTax.price
+    }
   }
 
   // reset previous calculation
   assignPrice({product, target: 'price', ...priceWithTax, deprecatedPriceFieldsSupport})
-  assignPrice({product, target: 'final_price', ...finalPriceWithTax, deprecatedPriceFieldsSupport})
-  assignPrice({product, target: 'special_price', ...specialPriceWithTax, deprecatedPriceFieldsSupport})
+  if (specialPriceWithTax.price) {
+    assignPrice({product, target: 'special_price', ...specialPriceWithTax, deprecatedPriceFieldsSupport})
+  }
+  if (finalPriceWithTax.price) {
+    assignPrice({product, target: 'final_price', ...finalPriceWithTax, deprecatedPriceFieldsSupport})
+  }
 
   if (product.final_price) {
     if (product.final_price < product.price) { // compare the prices with the product final price if provided; final prices is used in case of active catalog promo rules for example
+      assignPrice({product, target: 'price', price: product.final_price, deprecatedPriceFieldsSupport})
       if (product.final_price < product.special_price) { // for VS - special_price is any price lowered than regular price (`price`); in Magento there is a separate mechanism for setting the `special_prices`
-        assignPrice({product, target: 'price', ...specialPriceWithTax, deprecatedPriceFieldsSupport}) // if the `final_price` is lower than the original `special_price` - it means some catalog rules were applied over it
+        assignPrice({product, target: 'price', price: product.special_price, deprecatedPriceFieldsSupport}) // if the `final_price` is lower than the original `special_price` - it means some catalog rules were applied over it
       }
-      assignPrice({product, target: 'special_price', ...finalPriceWithTax, deprecatedPriceFieldsSupport})
-    } else {
-      assignPrice({product, target: 'price', ...finalPriceWithTax, deprecatedPriceFieldsSupport})
+      assignPrice({product, target: 'special_price', price: product.final_price, deprecatedPriceFieldsSupport})
     }
   }
 
@@ -107,7 +114,7 @@ export function updateProductPrices ({ product, rate, sourcePriceInclTax = false
       // out of the dates period
       assignPrice({product, target: 'special_price', price: 0, tax: 0, deprecatedPriceFieldsSupport})
     } else {
-      assignPrice({product, target: 'price', ...specialPriceWithTax, deprecatedPriceFieldsSupport})
+      assignPrice({product, target: 'price', price: product.special_price, deprecatedPriceFieldsSupport})
     }
   } else {
     // the same price as original; it's not a promotion


### PR DESCRIPTION
- if product doesn't have field 'special_price', we get "Nan" value (and we can have null value in product.price), similar  case if for 'final_price' (problem appears after refactoring)

- fix calculating minimal price for configurable products. If `product.final_price < price.price' - final_price was not used as price