### PR TITLE
Replace Sharp's crop function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed some smaller issues with graphql so that it is now working again with the fronted - #350
+- Replaced the old `crop` function call which has been removed from Sharp image processor - @grimasod (#381)
 
 
 ## [1.11.0-rc.1] - 2019.10.03

--- a/src/lib/image.js
+++ b/src/lib/image.js
@@ -45,7 +45,7 @@ export async function fit (buffer, width, height) {
     const transformer = sharp(buffer);
 
     if (width || height) {
-      transformer.resize(width, height).crop();
+      transformer.resize(width, height, { fit: sharp.fit.cover });
     }
 
     return transformer.toBuffer();


### PR DESCRIPTION
The `crop` function was deprecated in v0.21.0 and removed in v0.22.0 of the Sharp image processor

https://sharp.pixelplumbing.com/en/stable/changelog/

This PR replaces the `crop` call with the new `fit` parameter of the `resize` function