### PR TITLE
#378 Check message prop instead of errorMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for tax calculation where the values from customer_tax_class_ids is used - @resubaka (#307)
 - The `db` context object - passed to every api endpoint now has two usefull methods: `getElasticClient` and `getRedisClient` for accesing the data stores - @pkarw (#328)
 - The `lib/utils` got two new methods `getStoreCode(req: Express.Request)` and `getStoreView(code: string)` for getting the current multistore context from `vue-storefront` frontend requests - @pkarw
+- Check message property instead of errorMessage in apiError function - @cdshotels-liborpansky (#378)
 
 ### Removed
 - The `scripts/seo.js` tool has been removed, the legacy `migrations` scripts have been removed, the unused legacy extensions (`gls-parcelshop-dk`, `postnord-parcelshop-dk`) - @pkarw (#342)

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -84,7 +84,9 @@ export function apiStatus (res, result = 'OK', code = 200, meta = null) {
  *  @param {json} [result='OK']    Text message or result information object
  */
 export function apiError (res, errorObj, code = 500) {
-  return apiStatus(res, errorObj.message ? errorObj.message : errorObj, errorObj.code ? errorObj.code : 500)
+  const result = errorObj.message ? errorObj.message : (errorObj.errorMessage ? errorObj.errorMessage : errorObj);
+  const resultCode = errorObj.code ? errorObj.code : 500;
+  return apiStatus(res, result, resultCode)
 }
 
 export function encryptToken (textToken, secret) {

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -84,7 +84,7 @@ export function apiStatus (res, result = 'OK', code = 200, meta = null) {
  *  @param {json} [result='OK']    Text message or result information object
  */
 export function apiError (res, errorObj, code = 500) {
-  return apiStatus(res, errorObj.errorMessage ? errorObj.errorMessage : errorObj, errorObj.code ? errorObj.code : 500)
+  return apiStatus(res, errorObj.message ? errorObj.message : errorObj, errorObj.code ? errorObj.code : 500)
 }
 
 export function encryptToken (textToken, secret) {

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -85,7 +85,7 @@ export function apiStatus (res, result = 'OK', code = 200, meta = null) {
  */
 export function apiError (res, errorObj, code = 500) {
   const result = errorObj.message ? errorObj.message : (errorObj.errorMessage ? errorObj.errorMessage : errorObj);
-  const resultCode = errorObj.code ? errorObj.code : 500;
+  const resultCode = errorObj.code ? errorObj.code : code;
   return apiStatus(res, result, resultCode)
 }
 


### PR DESCRIPTION
Check message property instead of errorMessage in apiError function to return correct error message from API.