### PR TITLE
Add  ES client support for authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add url module - @gibkigonzo (#3942)
 - The `response_format` query parameter to the `/api/catalog` endpoint. Currently there is just one additional format supported: `response_format=compact`. When used, the response format got optimized by: a) remapping the results, removing the `_source` from the `hits.hits`; b) compressing the JSON fields names according to the `config.products.fieldsToCompact`; c) removing the JSON fields from the `product.configurable_children` when their values === parent product values; overall response size reduced over -70% - @pkarw
 - The support for `SearchQuery` instead of the ElasticSearch DSL as for the input to `/api/catalog` - using `storefront-query-builder` package - @pkarw - https://github.com/DivanteLtd/vue-storefront/issues/2167
+- Add ElasticSearch client support for HTTP authentication - @cewald (#397)
 
 ## [1.11.0] - 2019.12.20
 

--- a/config/default.json
+++ b/config/default.json
@@ -21,6 +21,7 @@
     "host": "localhost",
     "port": 9200,
     "protocol": "http",
+    "requestTimeout": 5000,
     "min_score": 0.01,
     "indices": [
       "vue_storefront_catalog",

--- a/src/lib/elastic.js
+++ b/src/lib/elastic.js
@@ -85,15 +85,16 @@ function getHits (result) {
 }
 
 function getClient (config) {
-  const esConfig = { // as we're runing tax calculation and other data, we need a ES indexer
-    node: `${config.elasticsearch.protocol}://${config.elasticsearch.host}:${config.elasticsearch.port}`,
-    apiVersion: config.elasticsearch.apiVersion,
-    requestTimeout: 5000
-  }
+  let { host, port, protocol, apiVersion, requestTimeout } = config.elasticsearch
+  const node = `${protocol}://${host}:${port}`
+
+  let auth
   if (config.elasticsearch.user) {
-    esConfig.auth = config.elasticsearch.user + ':' + config.elasticsearch.password
+    const { user, password } = config.elasticsearch
+    auth = { username: user, password }
   }
-  return new es.Client(esConfig)
+
+  return new es.Client({ node, auth, apiVersion, requestTimeout })
 }
 
 function putAlias (db, originalName, aliasName, next) {


### PR DESCRIPTION
There are cases when you need a HTTP authentication for you ElasticSearch connection.
I'm using the official ES cloud for example and this uses an user authentication using a password and username.

This isn't supported yet in the `src/lib/elastic.js:getClient()` method of the current `develop` branch.

I added another config parameter to the method to make it possible to us a authentication. I also put the part for the `requestTimeout` into the config file to make this optionally configurable.