### PR TITLE
Add fallback for `sourcePriceInclTax` and `finalPriceInclTax` in `magento1` platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed some smaller issues with graphql so that it is now working again with the fronted - #350
 - Replaced the old `crop` function call which has been removed from Sharp image processor - @grimasod (#381)
+- Add fallback for `sourcePriceInclTax` and `finalPriceInclTax` in `magento1` platform - @cewald (#398)
 
 
 ## [1.11.0-rc.1] - 2019.10.03

--- a/src/platform/magento1/tax.js
+++ b/src/platform/magento1/tax.js
@@ -23,8 +23,8 @@ class TaxProxy extends AbstractTaxProxy {
             if (store.elasticsearch.index === indexName) {
               taxRegion = store.tax.defaultRegion
               taxCountry = store.tax.defaultCountry
-              sourcePriceInclTax = store.tax.sourcePriceIncludesTax
-              finalPriceInclTax = store.tax.finalPriceIncludesTax
+              sourcePriceInclTax = store.tax.sourcePriceIncludesTax || null
+              finalPriceInclTax = store.tax.finalPriceIncludesTax || null
               this._storeConfigTax = store.tax
               break;
             }


### PR DESCRIPTION
Add fallback if `sourcePriceInclTax` and `finalPriceInclTax` are not set in multistore store object in `magento1` platform.

If you set this values only globally (not for each store) but use `multistore` mode, the values of both parameters will alway be `undefined` because  they are not set in the store object which is iterated through: https://github.com/DivanteLtd/vue-storefront-api/blob/30e1938a933146634b06590d3c84bf5f9b06ff05/src/platform/magento1/tax.js#L21-L31

I added a simple fallback so the check which happens later in this method can replace the empty values with the global one:
https://github.com/DivanteLtd/vue-storefront-api/blob/30e1938a933146634b06590d3c84bf5f9b06ff05/src/platform/magento1/tax.js#L42-L47