### PR TITLE
fix elasticsearch client basic authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `response_format` query parameter to the `/api/catalog` endpoint. Currently there is just one additional format supported: `response_format=compact`. When used, the response format got optimized by: a) remapping the results, removing the `_source` from the `hits.hits`; b) compressing the JSON fields names according to the `config.products.fieldsToCompact`; c) removing the JSON fields from the `product.configurable_children` when their values === parent product values; overall response size reduced over -70% - @pkarw
 - The support for `SearchQuery` instead of the ElasticSearch DSL as for the input to `/api/catalog` - using `storefront-query-builder` package - @pkarw - https://github.com/DivanteLtd/vue-storefront/issues/2167
 
+### Fixed
+- Fix HTTP Basic Authentication for elasticsearch ( https://github.com/DivanteLtd/vue-storefront-api/pull/400 )
+
 ## [1.11.0] - 2019.12.20
 
 ### Fixed

--- a/src/lib/elastic.js
+++ b/src/lib/elastic.js
@@ -91,7 +91,10 @@ function getClient (config) {
     requestTimeout: 5000
   }
   if (config.elasticsearch.user) {
-    esConfig.auth = config.elasticsearch.user + ':' + config.elasticsearch.password
+    esConfig.auth = {
+      username: config.elasticsearch.user,
+      password: config.elasticsearch.password
+    }
   }
   return new es.Client(esConfig)
 }


### PR DESCRIPTION
Currently connecting to a HTTP Basic Auth protected Elasticsearch Server is not working.

This fixes the config object that is passed to the es lib