### PR TITLE
Process product data in new URL mapper endpoint (#401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed some smaller issues with graphql so that it is now working again with the fronted - #350
 - Replaced the old `crop` function call which has been removed from Sharp image processor - @grimasod (#381)
+- Add product processor to new URL mapper endpoint #401 - @cewald (#401, #403)
 
 
 ## [1.11.0-rc.1] - 2019.10.03

--- a/src/api/url/map.ts
+++ b/src/api/url/map.ts
@@ -103,6 +103,8 @@ const map = ({ config }) => {
         } else {
           return res.json(responseRecord)
         }
+      } else {
+        return res.json()
       }
     })
   })


### PR DESCRIPTION
Solves #401

> The new `/api/url/map/vue_storefront_catalog_de` endpoint returns a product object to the VSF which isn't processed by the product processor. In the VSF the url action method `saveFallbackData` then saves this response to the `elasticCache` storage and the data is shown wrong in the VSF:
> https://github.com/DivanteLtd/vue-storefront/blob/develop/core/modules/url/store/actions.ts#L193-L194
> 
> In my case the product prices are missing when I load a product details page because it is first loaded via the URL mapper, then stored in the cache and just loaded from that for the rest of the page.
> 
> This is related to the latest `develop` branch of the API and the VSF.
