### PR TITLE
Bugfix/support es 7 in map url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `response_format` query parameter to the `/api/catalog` endpoint. Currently there is just one additional format supported: `response_format=compact`. When used, the response format got optimized by: a) remapping the results, removing the `_source` from the `hits.hits`; b) compressing the JSON fields names according to the `config.products.fieldsToCompact`; c) removing the JSON fields from the `product.configurable_children` when their values === parent product values; overall response size reduced over -70% - @pkarw
 - The support for `SearchQuery` instead of the ElasticSearch DSL as for the input to `/api/catalog` - using `storefront-query-builder` package - @pkarw - https://github.com/DivanteLtd/vue-storefront/issues/2167
 
+### Fixed
+- add es7 support for map url module and fixed default index for es config - @gibkigonzo
+
 ## [1.11.0] - 2019.12.20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Then, please do change the `config/local.json` to start using the new Elastic AP
 ```json
   "elasticsearch": {
     "host": "localhost",
+    "index": "vue_storefront_catalog",
     "port": 9200,
     "protocol": "http",
     "min_score": 0.01,

--- a/config/default.json
+++ b/config/default.json
@@ -19,6 +19,7 @@
   },
   "elasticsearch": {
     "host": "localhost",
+    "index": "vue_storefront_catalog",
     "port": 9200,
     "protocol": "http",
     "min_score": 0.01,

--- a/src/api/extensions/elastic-stock/index.js
+++ b/src/api/extensions/elastic-stock/index.js
@@ -12,7 +12,7 @@ module.exports = ({
   const getStockList = (storeCode, skus) => {
     let storeView = getCurrentStoreView(storeCode)
     const esQuery = adjustQuery({
-      index: storeView.elasticsearch.indexName, // current index name
+      index: storeView.elasticsearch.index, // current index name
       type: 'product',
       _source_includes: ['stock'],
       body: bodybuilder().filter('terms', 'visibility', [2, 3, 4]).andFilter('term', 'status', 1).andFilter('terms', 'sku', skus).build()

--- a/src/api/url/map.ts
+++ b/src/api/url/map.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { apiStatus } from '../../lib/util';
+import { apiStatus, getCurrentStoreView, getCurrentStoreCode } from '../../lib/util';
 import { getClient as getElasticClient } from '../../lib/elastic'
 import get from 'lodash/get';
 
@@ -70,13 +70,13 @@ const checkFieldValueEquality = ({ config, result, value }) => {
 
 const map = ({ config }) => {
   const router = Router()
-  router.post('/:indexName', async (req, res) => {
+  router.post('/', async (req, res) => {
     const { url, excludeFields, includeFields } = req.body
     if (!url) {
       return apiStatus(res, 'Missing url', 500);
     }
 
-    const indexName = req.params.indexName
+    const indexName = getCurrentStoreView(getCurrentStoreCode(req)).elasticsearch.index
     const esQuery = {
       index: buildIndex({ indexName, config }), // current index name
       _source_includes: includeFields ? includeFields.concat(get(config, 'urlModule.map.includeFields', [])) : [],

--- a/src/api/url/map.ts
+++ b/src/api/url/map.ts
@@ -1,8 +1,23 @@
 import { Router } from 'express';
 import { apiStatus } from '../../lib/util';
-import { buildMultiEntityUrl } from '../../lib/elastic';
-import request from 'request';
+import { getClient as getElasticClient } from '../../lib/elastic'
 import get from 'lodash/get';
+
+const adjustQueryForOldES = ({ config }) => {
+  const searchedEntities = get(config, 'urlModule.map.searchedEntities', [])
+    .map((entity) => ({ type: { value: entity } }))
+  if (parseInt(config.elasticsearch.apiVersion) < 6) {
+    return {
+      filter: {
+        bool: {
+          should: searchedEntities
+        }
+      }
+    }
+  } else {
+    return {}
+  }
+}
 
 /**
  * Builds ES query based on config
@@ -10,8 +25,6 @@ import get from 'lodash/get';
 const buildQuery = ({ value, config }) => {
   const searchedFields = get(config, 'urlModule.map.searchedFields', [])
     .map((field) => ({ match_phrase: { [field]: { query: value } } }))
-  const searchedEntities = get(config, 'urlModule.map.searchedEntities', [])
-    .map((entity) => ({ type: { value: entity } }))
 
   return {
     query: {
@@ -19,11 +32,7 @@ const buildQuery = ({ value, config }) => {
         filter: {
           bool: {
             should: searchedFields,
-            filter: {
-              bool: {
-                should: searchedEntities
-              }
-            }
+            ...adjustQueryForOldES({ config })
           }
         }
       }
@@ -32,58 +41,62 @@ const buildQuery = ({ value, config }) => {
   }
 }
 
+const buildIndex = ({ indexName, config }) => {
+  return parseInt(config.elasticsearch.apiVersion) < 6
+    ? indexName
+    : get(config, 'urlModule.map.searchedEntities', [])
+      .map(entity => `${indexName}_${entity}`)
+}
+
+const adjustResultType = ({ result, config, indexName }) => {
+  if (parseInt(config.elasticsearch.apiVersion) < 6) return result
+
+  // extract type from index for es 7
+  const type = result._index.replace(new RegExp(`^(${indexName}_)|(_[^_]*)$`, 'g'), '')
+  result._type = type
+
+  return result
+}
+
 /**
  * checks result equality because ES can return record even if searched value is not EXACLY what we want (check `match_phrase` in ES docs)
  */
-const checkFieldValueEquality = ({ config, response, value }) => {
+const checkFieldValueEquality = ({ config, result, value }) => {
   const isEqualValue = get(config, 'urlModule.map.searchedFields', [])
-    .find((field) => response._source[field] === value)
+    .find((field) => result._source[field] === value)
 
   return Boolean(isEqualValue)
 }
 
 const map = ({ config }) => {
   const router = Router()
-  router.post('/:index', (req, res) => {
+  router.post('/:indexName', async (req, res) => {
     const { url, excludeFields, includeFields } = req.body
     if (!url) {
       return apiStatus(res, 'Missing url', 500);
     }
 
-    const esUrl = buildMultiEntityUrl({
-      config,
-      includeFields: includeFields ? includeFields.concat(get(config, 'urlModule.map.includeFields', [])) : [],
-      excludeFields
-    })
-    const query = buildQuery({ value: url, config })
-
-    // Only pass auth if configured
-    let auth = null;
-    if (config.elasticsearch.user || config.elasticsearch.password) {
-      auth = {
-        user: config.elasticsearch.user,
-        pass: config.elasticsearch.password
-      }
+    const indexName = req.params.indexName
+    const esQuery = {
+      index: buildIndex({ indexName, config }), // current index name
+      _source_includes: includeFields ? includeFields.concat(get(config, 'urlModule.map.includeFields', [])) : [],
+      _source_excludes: excludeFields,
+      body: buildQuery({ value: url, config })
     }
 
-    // make simple ES search
-    request({
-      uri: esUrl,
-      method: 'POST',
-      body: query,
-      json: true,
-      auth: auth
-    }, (_err, _res, _resBody) => {
-      if (_err) {
-        console.log(_err)
-        return apiStatus(res, new Error('ES search error'), 500);
+    try {
+      const esResponse = await getElasticClient(config).search(esQuery)
+      const result = get(esResponse, 'body.hits.hits[0]', null)
+
+      if (result && checkFieldValueEquality({ config, result, value: req.body.url })) {
+        return res.json(adjustResultType({ result, config, indexName }))
       }
-      const responseRecord = _resBody.hits.hits[0]
-      if (responseRecord && checkFieldValueEquality({ config, response: responseRecord, value: req.body.url })) {
-        return res.json(responseRecord)
-      }
-      res.json()
-    })
+
+      res.json(null)
+    } catch (err) {
+      console.error(err)
+      return apiStatus(res, new Error('ES search error'), 500);
+    }
   })
 
   return router

--- a/src/lib/elastic.js
+++ b/src/lib/elastic.js
@@ -57,17 +57,6 @@ function adjustBackendProxyUrl (req, indexName, entityType, config) {
   return url
 }
 
-/**
- * similar to `adjustBackendProxyUrl`, builds multi-entity query url
- */
-function buildMultiEntityUrl ({ config, includeFields = [], excludeFields = [] }) {
-  let url = `${config.elasticsearch.host}:${config.elasticsearch.port}/_search?_source_include=${includeFields.join(',')}&_source_exclude=${excludeFields.join(',')}`
-  if (!url.startsWith('http')) {
-    url = config.elasticsearch.protocol + '://' + url
-  }
-  return url
-}
-
 function adjustQuery (esQuery, entityType, config) {
   if (parseInt(config.elasticsearch.apiVersion) < 6) {
     esQuery.type = entityType
@@ -278,6 +267,5 @@ module.exports = {
   getClient,
   getHits,
   adjustIndexName,
-  putMappings,
-  buildMultiEntityUrl
+  putMappings
 }


### PR DESCRIPTION
- added es7 support for map url module - in es7 we dont search through multiple entities, but through multiple indexes
- fixed default index for es - getCurrentStoreView returns default es config, but there is missing index, same is needed for `src/api/extensions/elastic-stock/index.js`