### PR TITLE
Bug fix for elastic-stock extension

### DIFF
--- a/src/api/extensions/elastic-stock/index.js
+++ b/src/api/extensions/elastic-stock/index.js
@@ -1,5 +1,5 @@
 import { apiStatus, getCurrentStoreView, getCurrentStoreCode } from '../../../lib/util';
-import { getClient as getElasticClient, adjustQuery } from '../../../lib/elastic'
+import { getClient as getElasticClient, adjustQuery, getHits } from '../../../lib/elastic'
 import { Router } from 'express';
 const bodybuilder = require('bodybuilder')
 
@@ -18,8 +18,7 @@ module.exports = ({
       body: bodybuilder().filter('terms', 'visibility', [2, 3, 4]).andFilter('term', 'status', 1).andFilter('terms', 'sku', skus).build()
     }, 'product', config)
     return getElasticClient(config).search(esQuery).then((products) => { // we're always trying to populate cache - when online
-      console.log(products)
-      return products.hits.hits.map(el => { return el._source.stock })
+      return getHits(products).map(el => { return el._source.stock })
     }).catch(err => {
       console.error(err)
     })

--- a/src/api/extensions/elastic-stock/index.js
+++ b/src/api/extensions/elastic-stock/index.js
@@ -15,7 +15,7 @@ module.exports = ({
       index: storeView.elasticsearch.index, // current index name
       type: 'product',
       _source_includes: ['stock'],
-      body: bodybuilder().filter('terms', 'visibility', [2, 3, 4]).andFilter('term', 'status', 1).andFilter('terms', 'sku', skus).build()
+      body: bodybuilder().filter('term', 'status', 1).andFilter('terms', 'sku', skus).build()
     }, 'product', config)
     return getElasticClient(config).search(esQuery).then((products) => { // we're always trying to populate cache - when online
       return getHits(products).map(el => { return el._source.stock })


### PR DESCRIPTION
This fixes the issues described in #402, #389 and #388

* makes `elastic-stock` extension compatible with both ES5 and ES7
* Allows for stock fetch of configurable children that is set as "Not Visible Individually"