### PR TITLE
backport fixes from develop to 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - UNRELEASED
+
+### Added
+- Add save address on place order - @lucasqm (#394)
+
+### Fixed
+- Add fallback for `sourcePriceInclTax` and `finalPriceInclTax` in `magento1` platform - @cewald (#398)
+- Add default ES index to config and update `getStockList` - @gibkigonzo (#405)
+- Makes elastic-stock extension compatible with both ES5 and ES7. Allows for stock fetch of configurable children that is set as "Not Visible Individually" - @didkan (#410)
+
+
 ## [1.11.0] - 2019.12.20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add save address on place order - @lucasqm (#394)
+- Add ElasticSearch client support for HTTP authentication - @cewald (#397)
+- Add error handling for catalog and add header 'X-VS-Cache-Tags' to response - @gibkigonzo
 
 ### Fixed
 - Add fallback for `sourcePriceInclTax` and `finalPriceInclTax` in `magento1` platform - @cewald (#398)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Then, please do change the `config/local.json` to start using the new Elastic AP
 ```json
   "elasticsearch": {
     "host": "localhost",
+    "index": "vue_storefront_catalog",
     "port": 9200,
     "protocol": "http",
     "min_score": 0.01,

--- a/config/default.json
+++ b/config/default.json
@@ -19,6 +19,7 @@
   },
   "elasticsearch": {
     "host": "localhost",
+    "index": "vue_storefront_catalog",
     "port": 9200,
     "protocol": "http",
     "min_score": 0.01,

--- a/config/default.json
+++ b/config/default.json
@@ -22,6 +22,7 @@
     "index": "vue_storefront_catalog",
     "port": 9200,
     "protocol": "http",
+    "requestTimeout": 5000,
     "min_score": 0.01,
     "indices": [
       "vue_storefront_catalog",

--- a/src/api/catalog.js
+++ b/src/api/catalog.js
@@ -4,6 +4,7 @@ import ProcessorFactory from '../processor/factory';
 import { adjustBackendProxyUrl } from '../lib/elastic'
 import cache from '../lib/cache-instance'
 import { sha3_224 } from 'js-sha3'
+import { apiError } from '../lib/util';
 
 function _cacheStorageHandler (config, result, hash, tags) {
   if (config.server.useOutputCache && cache) {
@@ -86,43 +87,41 @@ export default ({config, db}) => function (req, res, body) {
       body: requestBody,
       json: true,
       auth: auth
-    }, (_err, _res, _resBody) => { // TODO: add caching layer to speed up SSR? How to invalidate products (checksum on the response BEFORE processing it)
-      if (_resBody && _resBody.hits && _resBody.hits.hits) { // we're signing up all objects returned to the client to be able to validate them when (for example order)
-        const factory = new ProcessorFactory(config)
-        const tagsArray = []
-        if (config.server.useOutputCache && cache) {
-          const tagPrefix = entityType[0].toUpperCase() // first letter of entity name: P, T, A ...
-          tagsArray.push(entityType)
-          _resBody.hits.hits.map(item => {
-            if (item._source.id) { // has common identifier
-              tagsArray.push(`${tagPrefix}${item._source.id}`)
-            }
-          })
+    }, async (_err, _res, _resBody) => { // TODO: add caching layer to speed up SSR? How to invalidate products (checksum on the response BEFORE processing it)
+      if (_err || _resBody.error) {
+        apiError(res, _err || _resBody.error);
+        return
+      }
+      try {
+        if (_resBody && _resBody.hits && _resBody.hits.hits) { // we're signing up all objects returned to the client to be able to validate them when (for example order)
+          const factory = new ProcessorFactory(config)
+          const tagsArray = []
+          if (config.server.useOutputCache && cache) {
+            const tagPrefix = entityType[0].toUpperCase() // first letter of entity name: P, T, A ...
+            tagsArray.push(entityType)
+            _resBody.hits.hits.map(item => {
+              if (item._source.id) { // has common identifier
+                tagsArray.push(`${tagPrefix}${item._source.id}`)
+              }
+            })
+            const cacheTags = tagsArray.join(' ')
+            res.setHeader('X-VS-Cache-Tags', cacheTags)
+          }
+
+          let resultProcessor = factory.getAdapter(entityType, indexName, req, res)
+
+          if (!resultProcessor) { resultProcessor = factory.getAdapter('default', indexName, req, res) } // get the default processor
+
+          const productGroupId = entityType === 'product' ? groupId : undefined
+          const result = await resultProcessor.process(_resBody.hits.hits, productGroupId)
+          _resBody.hits.hits = result
+          _cacheStorageHandler(config, _resBody, reqHash, tagsArray)
+          res.json(_resBody);
+        } else { // no cache storage if no results from Elastic
+          res.json(_resBody);
         }
-
-        let resultProcessor = factory.getAdapter(entityType, indexName, req, res)
-
-        if (!resultProcessor) { resultProcessor = factory.getAdapter('default', indexName, req, res) } // get the default processor
-
-        if (entityType === 'product') {
-          resultProcessor.process(_resBody.hits.hits, groupId).then((result) => {
-            _resBody.hits.hits = result
-            _cacheStorageHandler(config, _resBody, reqHash, tagsArray)
-            res.json(_resBody);
-          }).catch((err) => {
-            console.error(err)
-          })
-        } else {
-          resultProcessor.process(_resBody.hits.hits).then((result) => {
-            _resBody.hits.hits = result
-            _cacheStorageHandler(config, _resBody, reqHash, tagsArray)
-            res.json(_resBody);
-          }).catch((err) => {
-            console.error(err)
-          })
-        }
-      } else { // no cache storage if no results from Elastic
-        res.json(_resBody);
+      } catch (err) {
+        apiError(res, err);
       }
     });
   }

--- a/src/api/extensions/elastic-stock/index.js
+++ b/src/api/extensions/elastic-stock/index.js
@@ -1,5 +1,5 @@
 import { apiStatus, getCurrentStoreView, getCurrentStoreCode } from '../../../lib/util';
-import { getClient as getElasticClient, adjustQuery } from '../../../lib/elastic'
+import { getClient as getElasticClient, adjustQuery, getHits } from '../../../lib/elastic'
 import { Router } from 'express';
 const bodybuilder = require('bodybuilder')
 
@@ -18,8 +18,7 @@ module.exports = ({
       body: bodybuilder().filter('terms', 'visibility', [2, 3, 4]).andFilter('term', 'status', 1).andFilter('terms', 'sku', skus).build()
     }, 'product', config)
     return getElasticClient(config).search(esQuery).then((products) => { // we're always trying to populate cache - when online
-      console.log(products)
-      return products.hits.hits.map(el => { return el._source.stock })
+      return getHits(products).map(el => { return el._source.stock })
     }).catch(err => {
       console.error(err)
     })

--- a/src/api/extensions/elastic-stock/index.js
+++ b/src/api/extensions/elastic-stock/index.js
@@ -15,7 +15,7 @@ module.exports = ({
       index: storeView.elasticsearch.index, // current index name
       type: 'product',
       _source_includes: ['stock'],
-      body: bodybuilder().filter('terms', 'visibility', [2, 3, 4]).andFilter('term', 'status', 1).andFilter('terms', 'sku', skus).build()
+      body: bodybuilder().filter('term', 'status', 1).andFilter('terms', 'sku', skus).build()
     }, 'product', config)
     return getElasticClient(config).search(esQuery).then((products) => { // we're always trying to populate cache - when online
       return getHits(products).map(el => { return el._source.stock })

--- a/src/api/extensions/elastic-stock/index.js
+++ b/src/api/extensions/elastic-stock/index.js
@@ -12,7 +12,7 @@ module.exports = ({
   const getStockList = (storeCode, skus) => {
     let storeView = getCurrentStoreView(storeCode)
     const esQuery = adjustQuery({
-      index: storeView.elasticsearch.indexName, // current index name
+      index: storeView.elasticsearch.index, // current index name
       type: 'product',
       _source_includes: ['stock'],
       body: bodybuilder().filter('terms', 'visibility', [2, 3, 4]).andFilter('term', 'status', 1).andFilter('terms', 'sku', skus).build()

--- a/src/lib/elastic.js
+++ b/src/lib/elastic.js
@@ -68,15 +68,16 @@ function getHits (result) {
 }
 
 function getClient (config) {
-  const esConfig = { // as we're runing tax calculation and other data, we need a ES indexer
-    node: `${config.elasticsearch.protocol}://${config.elasticsearch.host}:${config.elasticsearch.port}`,
-    apiVersion: config.elasticsearch.apiVersion,
-    requestTimeout: 5000
-  }
+  let { host, port, protocol, apiVersion, requestTimeout } = config.elasticsearch
+  const node = `${protocol}://${host}:${port}`
+
+  let auth
   if (config.elasticsearch.user) {
-    esConfig.auth = config.elasticsearch.user + ':' + config.elasticsearch.password
+    const { user, password } = config.elasticsearch
+    auth = { username: user, password }
   }
-  return new es.Client(esConfig)
+
+  return new es.Client({ node, auth, apiVersion, requestTimeout })
 }
 
 function putAlias (db, originalName, aliasName, next) {

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -83,8 +83,10 @@ export function apiStatus (res, result = 'OK', code = 200, meta = null) {
  *  @param {number} [code=200]    Status code to send on success
  *  @param {json} [result='OK']    Text message or result information object
  */
-export function apiError (res, errorObj, code = 500) {
-  return apiStatus(res, errorObj.errorMessage ? errorObj.errorMessage : errorObj, errorObj.code ? errorObj.code : 500)
+export function apiError (res, errorObj) {
+  const errorCode = errorObj.code || errorObj.status || 500
+  const errorMessage = errorObj.errorMessage || errorObj
+  return apiStatus(res, errorMessage, errorCode)
 }
 
 export function encryptToken (textToken, secret) {

--- a/src/models/order.schema.js
+++ b/src/models/order.schema.js
@@ -140,6 +140,9 @@ exports.default = {
             },
             sameAsBilling: {
               type: 'number'
+            },
+            save_address: {
+              type: 'number'              
             }
           }
         },
@@ -203,6 +206,9 @@ exports.default = {
               },
               sameAsBilling: {
                 type: 'number'
+              },
+              save_address: {
+                type: 'number'              
               }
             }
           }

--- a/src/models/order.schema.js
+++ b/src/models/order.schema.js
@@ -142,7 +142,7 @@ exports.default = {
               type: 'number'
             },
             save_address: {
-              type: 'number'              
+              type: 'number'
             }
           }
         },
@@ -208,7 +208,7 @@ exports.default = {
                 type: 'number'
               },
               save_address: {
-                type: 'number'              
+                type: 'number'
               }
             }
           }

--- a/src/platform/magento1/tax.js
+++ b/src/platform/magento1/tax.js
@@ -23,8 +23,8 @@ class TaxProxy extends AbstractTaxProxy {
             if (store.elasticsearch.index === indexName) {
               taxRegion = store.tax.defaultRegion
               taxCountry = store.tax.defaultCountry
-              sourcePriceInclTax = store.tax.sourcePriceIncludesTax
-              finalPriceInclTax = store.tax.finalPriceIncludesTax
+              sourcePriceInclTax = store.tax.sourcePriceIncludesTax || null
+              finalPriceInclTax = store.tax.finalPriceIncludesTax || null
               this._storeConfigTax = store.tax
               break;
             }

--- a/src/platform/magento2/o2m.js
+++ b/src/platform/magento2/o2m.js
@@ -158,7 +158,8 @@ function processSingleOrder (orderData, config, job, done, logger = console) {
               'regionCode': mappedBillingRegion.regionCode,
               'regionId': mappedBillingRegion.regionId,
               'company': billingAddr.company,
-              'vatId': billingAddr.vat_id
+              'vatId': billingAddr.vat_id,
+              'save_in_address_book': billingAddr.save_address
             }
           }
 
@@ -177,7 +178,8 @@ function processSingleOrder (orderData, config, job, done, logger = console) {
                 'regionCode': mappedBillingRegion.regionCode,
                 'region': billingAddr.region,
                 'company': billingAddr.company,
-                'vatId': billingAddr.vat_id
+                'vatId': billingAddr.vat_id,
+                'save_in_address_book': billingAddr.save_address
               },
               'shippingMethodCode': orderData.addressInformation.shipping_method_code,
               'shippingCarrierCode': orderData.addressInformation.shipping_carrier_code,
@@ -198,7 +200,8 @@ function processSingleOrder (orderData, config, job, done, logger = console) {
               'regionId': mappedShippingRegion.regionId,
               'regionCode': mappedShippingRegion.regionCode,
               'region': shippingAddr.region,
-              'company': shippingAddr.company
+              'company': shippingAddr.company,
+              'save_in_address_book': shippingAddr.save_address
             }
           } else {
             shippingAddressInfo['addressInformation']['shippingAddress'] = shippingAddressInfo['addressInformation']['billingAddress']


### PR DESCRIPTION
### Added
- Add save address on place order - @lucasqm (#394)
- Add ElasticSearch client support for HTTP authentication - @cewald (#397)
- Add error handling for catalog and add header 'X-VS-Cache-Tags' to response - @gibkigonzo

### Fixed
- Add fallback for `sourcePriceInclTax` and `finalPriceInclTax` in `magento1` platform - @cewald (#398)
- Add default ES index to config and update `getStockList` - @gibkigonzo (#405)
- Makes elastic-stock extension compatible with both ES5 and ES7. Allows for stock fetch of configurable children that is set as "Not Visible Individually" - @didkan (#410)