### PR TITLE
Add `resetPasswordUsingResetToken` to `magento1` platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ElasticSearch client support for HTTP authentication - @cewald (#397)
 - Endpoint for reset password with reset token. Only for Magento 2 - @Fifciu
 - Varnish Cache with autoinvalidation by Cache tags as addon - @Fifciu
+- Add `resetPasswordUsingResetToken` to `magento1` platform - @cewald (#415)
 
 ### Fixed
 - add es7 support for map url module and fixed default index for es config - @gibkigonzo

--- a/src/platform/magento1/user.js
+++ b/src/platform/magento1/user.js
@@ -34,6 +34,9 @@ class UserProxy extends AbstractUserProxy {
   changePassword (passwordData) {
     return this.api.user.changePassword(passwordData)
   }
+  resetPasswordUsingResetToken (resetData) {
+    return this.api.user.resetPasswordUsingResetToken(resetData)
+  }
 }
 
 module.exports = UserProxy


### PR DESCRIPTION
Add `resetPasswordUsingResetToken` method to `magento1` platform.

I also made related changes in the `magento1-vsbridge-client` here:
https://github.com/DivanteLtd/magento1-vsbridge-client/pull/11