### PR TITLE
add outputFormatter to response from cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - add es7 support for map url module and fixed default index for es config - @gibkigonzo
 - Add correct paths for production build - @cewald (#407)
+- Add outputFormatter to response from cache - @gibkigonzo (#428)
 
 ## [1.11.0] - 2019.12.20
 

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -182,7 +182,7 @@ export default ({config, db}) => async function (req, res, body) {
           res.setHeader('X-VS-Cache-Tag', tagsHeader)
           delete output.tags
         }
-        res.json(output)
+        res.json(_outputFormatter(output, responseFormat));
         console.log(`cache hit [${req.url}], cached request: ${Date.now() - s}ms`)
       } else {
         res.setHeader('X-VS-Cache', 'Miss')

--- a/src/models/order.schema.js
+++ b/src/models/order.schema.js
@@ -142,7 +142,7 @@ exports.default = {
               type: 'number'
             },
             save_address: {
-              type: 'number'              
+              type: 'number'
             }
           }
         },
@@ -208,7 +208,7 @@ exports.default = {
                 type: 'number'
               },
               save_address: {
-                type: 'number'              
+                type: 'number'
               }
             }
           }


### PR DESCRIPTION
We put output into cache before formatting, so when we get it from cache we need to add formater.