### PR TITLE
Update to `storefront-query-builder` version `1.0.0`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Endpoint for reset password with reset token. Only for Magento 2 - @Fifciu
 - Varnish Cache with autoinvalidation by Cache tags as addon - @Fifciu
 - Add `resetPasswordUsingResetToken` to `magento1` platform - @cewald (#415)
+- Update to `storefront-query-builder` version `1.0.0` - @cewald (#429)
 
 ### Fixed
 - add es7 support for map url module and fixed default index for es config - @gibkigonzo

--- a/config/default.json
+++ b/config/default.json
@@ -246,6 +246,7 @@
     "cms-data",
     "mail-service",
     "example-processor",
+    "example-custom-filter",
     "elastic-stock"
   ],
   "extensions": {

--- a/config/default.json
+++ b/config/default.json
@@ -271,6 +271,9 @@
       "resultProcessors": {
         "product": "my-product-processor"
       }
+    },
+    "example-custom-filter": {
+      "catalogFilter": [ "SampleFilter" ]
     }
   },
   "magento2": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ajv": "^6.4.0",
     "ajv-keywords": "^3.4.0",
     "body-parser": "^1.18.2",
-    "bodybuilder": "2.2.13",
+    "bodybuilder": "2.2.21",
     "commander": "^2.19.0",
     "compression": "^1.7.2",
     "config": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "resource-router-middleware": "^0.6.0",
     "sharp": "^0.23.4",
     "soap": "^0.25.0",
-    "storefront-query-builder": "^0.0.9",
+    "storefront-query-builder": "^1.0.0",
     "syswide-cas": "latest",
     "winston": "^2.4.2"
   },

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -7,6 +7,7 @@ import { sha3_224 } from 'js-sha3'
 import AttributeService from './attribute/service'
 import bodybuilder from 'bodybuilder'
 import { elasticsearch, SearchQuery } from 'storefront-query-builder'
+import loadCustomFilters from '../helpers/loadCustomFilters'
 
 function _cacheStorageHandler (config, result, hash, tags) {
   if (config.server.useOutputCache && cache) {
@@ -54,7 +55,8 @@ export default ({config, db}) => async function (req, res, body) {
   }
 
   if (req.query.request_format === 'search-query') { // search query and not Elastic DSL - we need to translate it
-    requestBody = await elasticsearch.buildQueryBodyFromSearchQuery({ config, queryChain: bodybuilder(), searchQuery: new SearchQuery(requestBody) })
+    const customFilters = await loadCustomFilters(config)
+    requestBody = await elasticsearch.buildQueryBodyFromSearchQuery({ config, queryChain: bodybuilder(), searchQuery: new SearchQuery(requestBody), customFilters })
   }
   if (req.query.response_format) responseFormat = req.query.response_format
 

--- a/src/api/extensions/example-custom-filter/filter/catalog/SampleFilter.ts
+++ b/src/api/extensions/example-custom-filter/filter/catalog/SampleFilter.ts
@@ -1,0 +1,13 @@
+import { FilterInterface } from 'storefront-query-builder'
+
+const filter: FilterInterface = {
+  priority: 1,
+  check: ({ operator, value, attribute, queryChain }) => attribute === 'custom-filter-name',
+  filter ({ value, attribute, operator, queryChain }) {
+    // Do you custom filter logic like: queryChain.filter('terms', attribute, value)
+    return queryChain
+  },
+  mutator: (value) => typeof value !== 'object' ? { 'in': [value] } : value
+}
+
+export default filter

--- a/src/api/extensions/example-custom-filter/index.ts
+++ b/src/api/extensions/example-custom-filter/index.ts
@@ -1,0 +1,6 @@
+import { Router } from 'express'
+
+module.exports = () => {
+  let exampleFilter = Router()
+  return exampleFilter
+}

--- a/src/helpers/loadCustomFilters.ts
+++ b/src/helpers/loadCustomFilters.ts
@@ -1,0 +1,32 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+function getModuleFilterPaths (moduleName: string, type: string): Promise<any> {
+  const dirPath = path.resolve(__dirname, '../../' + moduleName + '/filter/', type)
+  return fs.readdir(dirPath)
+    .then(files => files.filter(f => f.endsWith('Filter.ts')).map(file => ({ path: path.resolve(dirPath, file), file })))
+    .catch(() => {
+      return []
+    })
+}
+
+export default async function loadModuleCustomFilters (config: Record<string, any>, type: string = 'catalog'): Promise<any> {
+  let filters: any = {}
+  let filterPromises: Promise<any>[] = []
+
+  for (const ext in config.registeredExtensions) {
+    filterPromises.push(
+      getModuleFilterPaths(config.registeredExtensions[ext], type)
+        .then(filePaths => filePaths.forEach(o => import(o.path)
+          .then(module => {
+            filters[o.file] = module.default
+          })
+          .catch(e => {
+            console.log(e)
+          }))
+        )
+    )
+  }
+
+  return Promise.all(filterPromises).then((e) => filters)
+}

--- a/src/helpers/loadCustomFilters.ts
+++ b/src/helpers/loadCustomFilters.ts
@@ -1,31 +1,26 @@
-import { promises as fs } from 'fs'
 import path from 'path'
-
-function getModuleFilterPaths (moduleName: string, type: string): Promise<any> {
-  const dirPath = path.resolve(__dirname, '../../' + moduleName + '/filter/', type)
-  return fs.readdir(dirPath)
-    .then(files => files.filter(f => f.endsWith('Filter.ts')).map(file => ({ path: path.resolve(dirPath, file), file })))
-    .catch(() => {
-      return []
-    })
-}
 
 export default async function loadModuleCustomFilters (config: Record<string, any>, type: string = 'catalog'): Promise<any> {
   let filters: any = {}
   let filterPromises: Promise<any>[] = []
 
-  for (const ext in config.registeredExtensions) {
-    filterPromises.push(
-      getModuleFilterPaths(config.registeredExtensions[ext], type)
-        .then(filePaths => filePaths.forEach(o => import(o.path)
-          .then(module => {
-            filters[o.file] = module.default
-          })
-          .catch(e => {
-            console.log(e)
-          }))
+  for (const mod of config.registeredExtensions) {
+    if (config.extensions.hasOwnProperty(mod) && config.extensions[mod].hasOwnProperty(type + 'Filter') && Array.isArray(config.extensions[mod][type + 'Filter'])) {
+      const moduleFilter = config.extensions[mod][type + 'Filter']
+      const dirPath = [__dirname, '../api/extensions/' + mod + '/filter/', type]
+      for (const filterName of moduleFilter) {
+        const filePath = path.resolve(...dirPath, filterName + '.ts')
+        filterPromises.push(
+          import(filePath)
+            .then(module => {
+              filters[filterName] = module.default
+            })
+            .catch(e => {
+              console.log(e)
+            })
         )
-    )
+      }
+    }
   }
 
   return Promise.all(filterPromises).then((e) => filters)

--- a/src/helpers/loadCustomFilters.ts
+++ b/src/helpers/loadCustomFilters.ts
@@ -9,7 +9,7 @@ export default async function loadModuleCustomFilters (config: Record<string, an
       const moduleFilter = config.extensions[mod][type + 'Filter']
       const dirPath = [__dirname, '../api/extensions/' + mod + '/filter/', type]
       for (const filterName of moduleFilter) {
-        const filePath = path.resolve(...dirPath, filterName + '.ts')
+        const filePath = path.resolve(...dirPath, filterName)
         filterPromises.push(
           import(filePath)
             .then(module => {

--- a/src/models/order.schema.js
+++ b/src/models/order.schema.js
@@ -142,7 +142,7 @@ exports.default = {
               type: 'number'
             },
             save_address: {
-              type: 'number'              
+              type: 'number'
             }
           }
         },
@@ -208,7 +208,7 @@ exports.default = {
                 type: 'number'
               },
               save_address: {
-                type: 'number'              
+                type: 'number'
               }
             }
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -505,6 +505,16 @@
     "@typescript-eslint/typescript-estree" "1.13.0"
     eslint-scope "^4.0.0"
 
+"@typescript-eslint/experimental-utils@2.27.0":
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.27.0.tgz#801a952c10b58e486c9a0b36cf21e2aab1e9e01a"
+  integrity sha512-vOsYzjwJlY6E0NJRXPTeCGqjv5OHgRU1kzxHKWJVPjDYGbPgLudBXjIlc+OD1hDBZ4l1DLbOc5VjofKahsu9Jw==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.27.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
 "@typescript-eslint/parser@^1.7.1-alpha.17":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.13.0.tgz#61ac7811ea52791c47dc9fd4dd4a184fae9ac355"
@@ -514,12 +524,35 @@
     "@typescript-eslint/typescript-estree" "1.13.0"
     eslint-visitor-keys "^1.0.0"
 
+"@typescript-eslint/parser@^2.26.0":
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.27.0.tgz#d91664335b2c46584294e42eb4ff35838c427287"
+  integrity sha512-HFUXZY+EdwrJXZo31DW4IS1ujQW3krzlRjBrFRrJcMDh0zCu107/nRfhk/uBasO8m0NVDbBF5WZKcIUMRO7vPg==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "2.27.0"
+    "@typescript-eslint/typescript-estree" "2.27.0"
+    eslint-visitor-keys "^1.1.0"
+
 "@typescript-eslint/typescript-estree@1.13.0":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz#8140f17d0f60c03619798f1d628b8434913dc32e"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
+
+"@typescript-eslint/typescript-estree@2.27.0":
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.27.0.tgz#a288e54605412da8b81f1660b56c8b2e42966ce8"
+  integrity sha512-t2miCCJIb/FU8yArjAvxllxbTiyNqaXJag7UOpB5DVoM3+xnjeOngtqlJkLRnMtzaRcJhe3CIR9RmL40omubhg==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
 
 JSONStream@^1.3.5:
   version "1.3.5"
@@ -2021,15 +2054,35 @@ eslint-scope@^4.0.0, eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
+  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-utils@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.0.tgz#e2c3c8dba768425f897cf0f9e51fe2e241485d4c"
   dependencies:
     eslint-visitor-keys "^1.0.0"
 
+eslint-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.0.0.tgz#7be1cc70f27a72a76cd14aa698bcabed6890e1cd"
+  integrity sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint-visitor-keys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
+  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
 eslint@^5.0.0:
   version "5.16.0"
@@ -2624,6 +2677,18 @@ glob@^7.0.0, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 global-dirs@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
@@ -3133,7 +3198,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0:
+is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   dependencies:
@@ -6106,10 +6171,12 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
-"storefront-query-builder@https://github.com/DivanteLtd/storefront-query-builder.git":
-  version "0.0.8"
-  resolved "https://github.com/DivanteLtd/storefront-query-builder.git#26d17c9ae043b54725032687f116b21e83e02a77"
+storefront-query-builder@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/storefront-query-builder/-/storefront-query-builder-1.0.0.tgz#8bab0b6bd61a574dfa913cad5c2fdd17858f8b07"
+  integrity sha512-j0JhHOYhcfDcsBUMYWVJ0UApQDOem5zo20XikxJcxfFEcM5Et1Z16674wx3++KrWCbU5raEMgHvqEPxkDFajdw==
   dependencies:
+    "@typescript-eslint/parser" "^2.26.0"
     clone-deep "^4.0.1"
 
 stream-events@^1.0.1, stream-events@^1.0.4:
@@ -6468,6 +6535,13 @@ ts-node@^8.1.0:
 tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tsutils@^3.7.0:
   version "3.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,11 +999,12 @@ body-parser@1.19.0, body-parser@^1.12.2, body-parser@^1.17.1, body-parser@^1.18.
     raw-body "2.4.0"
     type-is "~1.6.17"
 
-bodybuilder@2.2.13:
-  version "2.2.13"
-  resolved "https://registry.yarnpkg.com/bodybuilder/-/bodybuilder-2.2.13.tgz#82ced1c2144bd9ddce97c5d89fa13f7e24c40f8e"
+bodybuilder@2.2.21:
+  version "2.2.21"
+  resolved "https://registry.yarnpkg.com/bodybuilder/-/bodybuilder-2.2.21.tgz#1a7a5d31189cf10a6fbd87668ac8aa386ac8cc38"
+  integrity sha512-Ys0Cas7ri7dcv3f62HwB2Lclk2oBCv86pakuEs4liK6hhL9ikTEairZ700k4VHD7vgvr2CW2Kogh4E5Ivmkg2A==
   dependencies:
-    lodash "^4.9.0"
+    lodash "^4.17.11"
 
 boxen@^1.2.1:
   version "1.3.0"
@@ -3990,7 +3991,7 @@ lodash.unescape@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.9.0:
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
 


### PR DESCRIPTION
Update to `storefront-query-builder` version `1.0.0`

This is connected to the update of `storefront-query-builder` to support new features as extendable filters and more customizable sorting.

Read more about here: https://github.com/DivanteLtd/storefront-query-builder/pull/6

---

* Add helper to import custom filters automatically
* Add a sample custom filter in `example-custom-filter` module
* Update `bodybuilder` package to `2.2.21` to be able to use the `clone` method
* Add `.eslintignore` to ignore `node_modules`

The version number I added is not yet connected to a valid `npm` package and therefore would fail while `yarn install`. To test it, you can checkout the new `storefront-query-builder` branch of PR above and connect it to your local `yarn` instance using `yarn build && yarn link`. And then run `yarn link "storefront-query-builder"` in your API folder. If you run `yarn install` afterwards it should be able to install the new package from your custom source instead from the package-managers remote source.