### PR TITLE
disable showing stack for invalid requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add correct paths for production build - @cewald (#407)
 - Fix MSI default stock id value
 - Add outputFormatter to response from cache - @gibkigonzo (#428)
+- disable showing stack for invalid requests - @gibkigonzo (#431)
 
 
 ## [1.11.1] - 2020.03.17

--- a/config/default.json
+++ b/config/default.json
@@ -9,7 +9,8 @@
     "availableCacheTags": ["P", "C", "T", "A", "product", "category", "attribute", "taxrule"],
     "invalidateCacheKey": "aeSu7aip",
     "invalidateCacheForwarding": false,
-    "invalidateCacheForwardUrl": "http://localhost:3000/invalidate?key=aeSu7aip&tag="
+    "invalidateCacheForwardUrl": "http://localhost:3000/invalidate?key=aeSu7aip&tag=",
+    "showErrorStack": false
   },
   "orders": {
     "useServerQueue": false

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,12 +73,15 @@ app.use('/graphiql', graphiqlExpress({ endpointURL: '/graphql' }));
 
 app.use((err, req, res, next) => {
   const { statusCode, message, stack } = err;
+  const stackTrace = stack
+    .split(/\r?\n/)
+    .map(string => string.trim())
+    .filter(string => string !== '')
+
   res.status(statusCode).json({
     code: statusCode,
-    result: config.get('server.showErrorStack') ? `
-      message: ${message};
-      stack: ${stack}
-    ` : message
+    result: message,
+    ...(config.get('server.showErrorStack') ? { stack: stackTrace } : {})
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ app.use('/graphql', graphqlExpress(req => ({
 app.use('/graphiql', graphiqlExpress({ endpointURL: '/graphql' }));
 
 app.use((err, req, res, next) => {
-  const { statusCode, message, stack } = err;
+  const { statusCode, message = '', stack = '' } = err;
   const stackTrace = stack
     .split(/\r?\n/)
     .map(string => string.trim())

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,4 +71,15 @@ app.use('/graphql', graphqlExpress(req => ({
 
 app.use('/graphiql', graphiqlExpress({ endpointURL: '/graphql' }));
 
+app.use((err, req, res, next) => {
+  const { statusCode, message, stack } = err;
+  res.status(statusCode).json({
+    code: statusCode,
+    result: config.get('server.showErrorStack') ? `
+      message: ${message};
+      stack: ${stack}
+    ` : message
+  });
+});
+
 export default app;


### PR DESCRIPTION
A simple call to  https:/demo.vuestorefront.io/api/catalog  lead to an exposure. The exception expose full path and some node modules names.
Calls that need to submit JSON (Content-type: application/json) can be exploited by sending anything but valid JSON :

curl -i -s -k -X $'GET' -H $'Host: demo.storefrontcloud.io' -H $'Accept: */*' -H $'Content-Type: application/json' -H $'Origin: https://demo.vuestorefront.io' -H $'Content-Length: 2' --data-binary $'\x0d\x0a' $'https://demo.storefrontcloud.io/api/cart/pull?token=&cartId='

before:
```
HTTP/1.1 400 Bad Request
X-Powered-By: Express
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Link
Content-Security-Policy: default-src 'none'
X-Content-Type-Options: nosniff
Content-Type: text/html; charset=utf-8
Content-Length: 1083
Date: Thu, 09 Apr 2020 15:15:07 GMT
Connection: keep-alive

<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>TypeError: Cannot read property &#39;1&#39; of null<br> &nbsp; &nbsp;at firstchar (/home/tkostuch/projects/vue-storefront-api/node_modules/body-parser/lib/types/json.js:176:37)<br> &nbsp; &nbsp;at parse (/home/tkostuch/projects/vue-storefront-api/node_modules/body-parser/lib/types/json.js:79:19)<br> &nbsp; &nbsp;at /home/tkostuch/projects/vue-storefront-api/node_modules/body-parser/lib/read.js:121:18<br> &nbsp; &nbsp;at invokeCallback (/home/tkostuch/projects/vue-storefront-api/node_modules/raw-body/index.js:224:16)<br> &nbsp; &nbsp;at done (/home/tkostuch/projects/vue-storefront-api/node_modules/raw-body/index.js:213:7)<br> &nbsp; &nbsp;at IncomingMessage.onEnd (/home/tkostuch/projects/vue-storefront-api/node_modules/raw-body/index.js:273:7)<br> &nbsp; &nbsp;at IncomingMessage.emit (events.js:203:15)<br> &nbsp; &nbsp;at endReadableNT (_stream_readable.js:1145:12)<br> &nbsp; &nbsp;at process._tickCallback (internal/process/next_tick.js:63:19)</pre>
</body>
</html>
```

after with disabled `showErrorStack`:
```
HTTP/1.1 400 Bad Request
X-Powered-By: Express
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Link
Content-Type: application/json; charset=utf-8
Content-Length: 56
ETag: W/"38-FJOVPF8Z1lnPViv6AcalthoI+wI"
Date: Thu, 09 Apr 2020 15:16:42 GMT
Connection: keep-alive

{"code":400,"result":"Cannot read property '1' of null"}
```

after with enabled `showErrorStack`:
```
HTTP/1.1 400 Bad Request
X-Powered-By: Express
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Link
Content-Type: application/json; charset=utf-8
Content-Length: 935
ETag: W/"3a7-5IXEycejIwEkQtThl5s+fZQ2NH4"
Date: Thu, 09 Apr 2020 15:17:56 GMT
Connection: keep-alive

{"code":400,"result":"\n      message: Cannot read property '1' of null;\n      stack: TypeError: Cannot read property '1' of null\n    at firstchar (/home/tkostuch/projects/vue-storefront-api/node_modules/body-parser/lib/types/json.js:176:37)\n    at parse (/home/tkostuch/projects/vue-storefront-api/node_modules/body-parser/lib/types/json.js:79:19)\n    at /home/tkostuch/projects/vue-storefront-api/node_modules/body-parser/lib/read.js:121:18\n    at invokeCallback (/home/tkostuch/projects/vue-storefront-api/node_modules/raw-body/index.js:224:16)\n    at done (/home/tkostuch/projects/vue-storefront-api/node_modules/raw-body/index.js:213:7)\n    at IncomingMessage.onEnd (/home/tkostuch/projects/vue-storefront-api/node_modules/raw-body/index.js:273:7)\n    at IncomingMessage.emit (events.js:203:15)\n    at endReadableNT (_stream_readable.js:1145:12)\n    at process._tickCallback (internal/process/next_tick.js:63:19)\n    "}
```