### PR TITLE
Improve `_outputFormatter` on cache catalog-response to prevent exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix MSI default stock id value
 - Add outputFormatter to response from cache - @gibkigonzo (#428)
 - disable showing stack for invalid requests - @gibkigonzo (#431)
-
+- Remove `_outputFormatter` from cache catalog-response to prevent exception - @cewald (#432)
 
 ## [1.11.1] - 2020.03.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix MSI default stock id value
 - Add outputFormatter to response from cache - @gibkigonzo (#428)
 - disable showing stack for invalid requests - @gibkigonzo (#431)
-- Remove `_outputFormatter` from cache catalog-response to prevent exception - @cewald (#432)
+- Improve `_outputFormatter` on cache catalog-response to prevent exception - @cewald (#432)
 
 ## [1.11.1] - 2020.03.17
 

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -10,9 +10,9 @@ import loadCustomFilters from '../helpers/loadCustomFilters'
 import { elasticsearch, SearchQuery } from 'storefront-query-builder'
 import { apiError } from '../lib/util'
 
-function _cacheStorageHandler (config, result, hash, tags) {
+async function _cacheStorageHandler (config, result, hash, tags) {
   if (config.server.useOutputCache && cache) {
-    cache.set(
+    return cache.set(
       'api:' + hash,
       result,
       tags
@@ -155,7 +155,7 @@ export default ({config, db}) => async function (req, res, body) {
           } else {
             _cacheStorageHandler(config, _resBody, reqHash, tagsArray)
           }
-          res.json(_outputFormatter(_resBody, responseFormat));
+          res.json(_outputFormatter(Object.assign({}, _resBody), responseFormat))
         } else { // no cache storage if no results from Elastic
           res.json(_resBody);
         }
@@ -176,7 +176,7 @@ export default ({config, db}) => async function (req, res, body) {
           res.setHeader('X-VS-Cache-Tag', tagsHeader)
           delete output.tags
         }
-        res.json(output)
+        res.json(_outputFormatter(output, responseFormat))
         console.log(`cache hit [${req.url}], cached request: ${Date.now() - s}ms`)
       } else {
         res.setHeader('X-VS-Cache', 'Miss')

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -176,7 +176,7 @@ export default ({config, db}) => async function (req, res, body) {
           res.setHeader('X-VS-Cache-Tag', tagsHeader)
           delete output.tags
         }
-        res.json(_outputFormatter(output, responseFormat));
+        res.json(output)
         console.log(`cache hit [${req.url}], cached request: ${Date.now() - s}ms`)
       } else {
         res.setHeader('X-VS-Cache', 'Miss')


### PR DESCRIPTION
I removed the `_outputFormatter` from output-cache response in the `catalog` endpoint.

This change came with this commit: e45bbec373e405df02390d5bb62fdb80bae3a2d5.
I'm not sure if this is correct. If I see straight, the output is already formatted before it is put into the cache using the `resultProcessor`.

In my case, this leads into an exception on each cached request – the first (uncached) works, the second fails with:
```
TypeError: Cannot read property 'map' of undefined
    at _outputFormatter (/vue-storefront-api/src/api/catalog.ts:34:50)
    at /vue-storefront-api/src/api/catalog.ts:180:18
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

This, of course, only appears if `useOutputCache` is enabled.