### PR TITLE
Bugfix for wrong JSON scheme url's and hostname resolution for `magento1` platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - disable showing stack for invalid requests - @gibkigonzo (#431)
 - Improve `_outputFormatter` on cache catalog-response to prevent exception - @cewald (#432)
 - use ts for compiling additional scripts - @gibkigonzo (#437)
+- Bugfix for wrong JSON scheme url's and hostname resolution for `magento1` platform - @cewald (#443)
 
 ## [1.11.1] - 2020.03.17
 

--- a/src/api/order.ts
+++ b/src/api/order.ts
@@ -5,6 +5,7 @@ import PlatformFactory from '../platform/factory';
 
 const Ajv = require('ajv'); // json validator
 const fs = require('fs');
+const path = require('path');
 const kue = require('kue');
 const jwa = require('jwa');
 const hmac = jwa('HS256');
@@ -29,7 +30,7 @@ export default ({ config, db }) => resource({
 
     const orderSchema = require('../models/order.schema.js')
     let orderSchemaExtension = {}
-    if (fs.existsSync('../models/order.schema.extension.json')) {
+    if (fs.existsSync(path.resolve(__dirname, '../models/order.schema.extension.json'))) {
       orderSchemaExtension = require('../models/order.schema.extension.json')
     }
     const validate = ajv.compile(merge(orderSchema, orderSchemaExtension));

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -6,6 +6,7 @@ import { merge } from 'lodash';
 
 const Ajv = require('ajv'); // json validator
 const fs = require('fs');
+const path = require('path');
 
 function addUserGroupToken (config, result) {
   /**
@@ -36,7 +37,7 @@ export default ({config, db}) => {
     const ajv = new Ajv();
     const userRegisterSchema = require('../models/userRegister.schema.json')
     let userRegisterSchemaExtension = {};
-    if (fs.existsSync('../models/userRegister.schema.extension.json')) {
+    if (fs.existsSync(path.resolve(__dirname, '../models/userRegister.schema.extension.json'))) {
       userRegisterSchemaExtension = require('../models/userRegister.schema.extension.json');
     }
     const validate = ajv.compile(merge(userRegisterSchema, userRegisterSchemaExtension))
@@ -169,7 +170,7 @@ export default ({config, db}) => {
     const ajv = new Ajv();
     const userProfileSchema = require('../models/userProfile.schema.json')
     let userProfileSchemaExtension = {};
-    if (fs.existsSync('../models/userProfile.schema.extension.json')) {
+    if (fs.existsSync(path.resolve(__dirname, '../models/userProfile.schema.extension.json'))) {
       userProfileSchemaExtension = require('../models/userProfile.schema.extension.json');
     }
     const validate = ajv.compile(merge(userProfileSchema, userProfileSchemaExtension))

--- a/src/platform/magento1/util.js
+++ b/src/platform/magento1/util.js
@@ -12,7 +12,7 @@ export function multiStoreConfig (apiConfig, req) {
     if (config.magento1['api_' + storeCode]) {
       confCopy = Object.assign({}, config.magento1['api_' + storeCode]) // we're to use the specific api configuration - maybe even separate magento instance
     } else {
-      if (new RegExp('(/' + config.availableStores.join('|') + '/)', 'gm').exec(confCopy.url) === null) {
+      if (new RegExp('/(' + config.availableStores.join('|') + ')/', 'gm').exec(confCopy.url) === null) {
         confCopy.url = (confCopy.url).replace(/(vsbridge)/gm, `${storeCode}/$1`);
       }
     }


### PR DESCRIPTION
This fixes two things:

1. The schema extension files won't be found at the moment because the path needs to be relative `fs.existsSync()`. Right now the `fs.existsSync` check always returns `false`.

1. Also the resolution of the VSF bridge URL of the `magento1` platform has a flacky RegExp which will return true if a store-code string is found anywhere in the string but it should be match for strings that are surrounded by `/` only.