### PR TITLE
check if headers has been already sent in image middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - disable showing stack for invalid requests - @gibkigonzo (#431)
 - Improve `_outputFormatter` on cache catalog-response to prevent exception - @cewald (#432)
 - use ts for compiling additional scripts - @gibkigonzo (#437)
+- check if headers has been already sent in image middleware - @gibkigonzo (#434)
 
 ## [1.11.1] - 2020.03.17
 

--- a/src/api/img.ts
+++ b/src/api/img.ts
@@ -41,6 +41,10 @@ export default ({ config, db }) =>
       imageBuffer = imageAction.imageBuffer
     }
 
+    if (res.headersSent) {
+      return
+    }
+
     return res
       .type(imageAction.mimeType)
       .set({ 'Cache-Control': `max-age=${imageAction.maxAgeForResponse}` })


### PR DESCRIPTION
Closes: #434 
Description:
If img middleware can't fetch image then it sent response in `prossesImage`. Same can happen in other methods of `ImageAction`. This change will check if headers has been already send