### PR TITLE
Use correct value for defaultStockId

### DIFF
--- a/src/api/stock.js
+++ b/src/api/stock.js
@@ -12,7 +12,7 @@ export default ({ config, db }) => {
 
   const _getStockId = (storeCode) => {
     let storeView = config.storeViews[storeCode]
-    return storeView ? storeView.msi.stockId : config.defaultStockId
+    return storeView ? storeView.msi.stockId : config.msi.defaultStockId
   };
 
   /**


### PR DESCRIPTION
The default defaultStockId is situated under config.msi not in config.