### PR TITLE
Bugfix/original_price not calculated correctly due to tax bug

### DIFF
--- a/src/platform/magento1/tax.js
+++ b/src/platform/magento1/tax.js
@@ -39,10 +39,10 @@ class TaxProxy extends AbstractTaxProxy {
         taxCountry = this._config.tax.defaultCountry
       }
     }
-    if (sourcePriceInclTax === null) {
+    if (sourcePriceInclTax == null) {
       sourcePriceInclTax = this._config.tax.sourcePriceIncludesTax
     }
-    if (finalPriceInclTax === null) {
+    if (finalPriceInclTax == null) {
       finalPriceInclTax = this._config.tax.finalPriceIncludesTax
     }
     this._deprecatedPriceFieldsSupport = this._config.tax.deprecatedPriceFieldsSupport

--- a/src/platform/magento2/tax.js
+++ b/src/platform/magento2/tax.js
@@ -38,10 +38,10 @@ class TaxProxy extends AbstractTaxProxy {
         taxCountry = this._config.tax.defaultCountry
       }
     }
-    if (sourcePriceInclTax === null) {
+    if (sourcePriceInclTax == null) {
       sourcePriceInclTax = this._config.tax.sourcePriceIncludesTax
     }
-    if (finalPriceInclTax === null) {
+    if (finalPriceInclTax == null) {
       finalPriceInclTax = this._config.tax.finalPriceIncludesTax
     }
     this._deprecatedPriceFieldsSupport = this._config.tax.deprecatedPriceFieldsSupport


### PR DESCRIPTION
Fixes #463 

Use normal equality operator instead of strict equality operator to catch both `null` and `undefined` values for `sourcePriceInclTax`.
This makes sure we get proper calculation of `original_price` and its variants. 