### PR TITLE
add error status code as number in apiError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.12.1] - UNRELEASED
+
+### Fixed
+
+- add error status code as number in `apiError` - @gibkigonzo (#442)
+
+
 ## [1.12.0] - 2020.06.01
 
 ### Added

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -118,6 +118,7 @@ export default ({config, db}) => async function (req, res, body) {
       auth: auth
     }, async (_err, _res, _resBody) => { // TODO: add caching layer to speed up SSR? How to invalidate products (checksum on the response BEFORE processing it)
       if (_err || _resBody.error) {
+        console.error(_err || _resBody.error)
         apiError(res, _err || _resBody.error)
         return
       }

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -86,14 +86,14 @@ export function apiStatus (res, result = 'OK', code = 200, meta = null) {
  *  @return {json} [result='OK']    Text message or result information object
  */
 export function apiError (res, error) {
-  let errorCode = error.code || error.status || 500;
+  let errorCode = error.code || error.status;
   let errorMessage = error.errorMessage || error;
   if (error instanceof Error) {
     // Class 'Error' is not serializable with JSON.stringify, extract data explicitly.
     errorCode = error.code || errorCode;
     errorMessage = error.message;
   }
-  return apiStatus(res, errorMessage, errorCode);
+  return apiStatus(res, errorMessage, Number(errorCode) || 500);
 }
 
 export function encryptToken (textToken, secret) {


### PR DESCRIPTION
Closes: #442

ES returns error object where status code is a string:
```

{ Error: connect ETIMEDOUT 51.255.29.86:443
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1106:14)
  errno: 'ETIMEDOUT',
  code: 'ETIMEDOUT',
  syscall: 'connect',
  address: '51.255.29.86',
  port: 443 }
```

So when we pass to `apiStatus` a string then it will fail as unhandled rejection:

```
(node:8036) UnhandledPromiseRejectionWarning: RangeError [ERR_HTTP_INVALID_STATUS_CODE]: Invalid status code: ETIMEDOUT
    at ServerResponse.writeHead (_http_server.js:209:11)
    at ServerResponse.writeHead (/home/tkostuch/projects/vue-storefront-api/node_modules/on-headers/index.js:44:26)
    at ServerResponse._implicitHeader (_http_server.js:200:8)
    at write_ (_http_outgoing.js:585:9)
    at ServerResponse.end (_http_outgoing.js:702:5)
    at ServerResponse.send (/home/tkostuch/projects/vue-storefront-api/node_modules/express/lib/response.js:221:10)
    at ServerResponse.json (/home/tkostuch/projects/vue-storefront-api/node_modules/express/lib/response.js:267:15)
    at apiStatus (/home/tkostuch/projects/vue-storefront-api/src/lib/util.js:77:20)
    at Object.apiError (/home/tkostuch/projects/vue-storefront-api/src/lib/util.js:96:10)
    at /home/tkostuch/projects/vue-storefront-api/src/api/catalog.ts:121:9
```

Which will result in empty reponse.