### PR TITLE
Allow filter elasticsearch request for security reasons

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -40,7 +40,9 @@
       "review"
     ],
     "apiVersion": "5.6",
-
+    "useRequestFilter": false,
+    "overwriteRequestSourceParams": false,
+    "requestParamsBlacklist": [],
     "searchScoring": {
       "attributes": {
         "attribute_code": {
@@ -81,21 +83,21 @@
       "tax_class_id": "tci",
       "description": "desc",
       "minimal_regular_price": "mrp",
-      "final_price": "fp", 
-      "price": "p", 
+      "final_price": "fp",
+      "price": "p",
       "special_price": "sp",
       "original_final_price": "ofp",
       "original_price": "op",
       "original_special_price": "osp",
-      "final_price_incl_tax": "fpit", 
+      "final_price_incl_tax": "fpit",
       "original_price_incl_tax": "opit",
       "price_incl_tax": "pit",
-      "special_price_incl_tax": "spit", 
+      "special_price_incl_tax": "spit",
       "final_price_tax": "fpt",
       "price_tax": "pt",
       "special_price_tax": "spt",
       "original_price_tax": "opt",
-      "image": "i", 
+      "image": "i",
       "small_image": "si",
       "thumbnail": "t"
     },
@@ -106,7 +108,7 @@
       "default": 10,
       "size": 10,
       "color": 10
-    },    
+    },
     "priceFilterKey": "final_price",
     "priceFilters": {
       "ranges": [
@@ -115,7 +117,7 @@
         { "from": 100, "to": 150 },
         { "from": 150 }
       ]
-    }    
+    }
   },
   "varnish": {
     "host": "185.246.52.88",
@@ -234,7 +236,7 @@
     "useOnlyDefaultUserGroupId": false
   },
   "review": {
-    "defaultReviewStatus": 2 
+    "defaultReviewStatus": 2
   },
   "bodyLimit": "100kb",
   "corsHeaders": [
@@ -346,15 +348,6 @@
       "attribute": {
         "includeFields": [ "attribute_code", "id", "entity_type_id", "options", "default_value", "is_user_defined", "frontend_label", "attribute_id", "default_frontend_label", "is_visible_on_front", "is_visible", "is_comparable" ],
         "loadByAttributeMetadata": false
-      },
-      "productList": {
-        "sort": "",
-        "includeFields": [ "type_id", "sku", "product_links", "tax_class_id", "special_price", "special_to_date", "special_from_date", "name", "price", "priceInclTax", "originalPriceInclTax", "originalPrice", "specialPriceInclTax", "id", "image", "sale", "new", "url_key" ],
-        "excludeFields": [ "configurable_children", "description", "configurable_options", "sgn" ]
-      },
-      "productListWithChildren": {
-        "includeFields": [ "type_id", "sku", "name", "tax_class_id", "special_price", "special_to_date", "special_from_date", "price", "priceInclTax", "originalPriceInclTax", "originalPrice", "specialPriceInclTax", "id", "image", "sale", "new", "configurable_children.image", "configurable_children.sku", "configurable_children.price", "configurable_children.special_price", "configurable_children.priceInclTax", "configurable_children.specialPriceInclTax", "configurable_children.originalPrice", "configurable_children.originalPriceInclTax", "configurable_children.color", "configurable_children.size", "product_links", "url_key"],
-        "excludeFields": [ "description", "sgn"]
       },
       "product": {
         "excludeFields": [ "updated_at", "created_at", "attribute_set_id", "status", "visibility", "tier_prices", "options_container", "msrp_display_actual_price_type", "has_options", "stock.manage_stock", "stock.use_config_min_qty", "stock.use_config_notify_stock_qty", "stock.stock_id",  "stock.use_config_backorders", "stock.use_config_enable_qty_inc", "stock.enable_qty_increments", "stock.use_config_manage_stock", "stock.use_config_min_sale_qty", "stock.notify_stock_qty", "stock.use_config_max_sale_qty", "stock.use_config_max_sale_qty", "stock.qty_increments", "small_image"],

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -84,7 +84,7 @@ export default ({config, db}) => async function (req, res, body) {
   }
 
   // pass the request to elasticsearch
-  let elasticBackendUrl = adjustBackendProxyUrl(req, indexName, entityType, config)
+  const elasticBackendUrl = adjustBackendProxyUrl(req, indexName, entityType, config)
   const userToken = requestBody.groupToken
 
   // Decode token and get group id

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -127,8 +127,10 @@ export default ({config, db}) => async function (req, res, body) {
       let _source_exclude = excludeFields
 
       if (!config.elasticsearch.overwriteRequestSourceParams) {
-        _source_include = [...includeFields, ...req.query._source_include]
-        _source_exclude = [...excludeFields, ...req.query._source_exclude]
+        const requestSourceInclude = req.query._source_include || []
+        const requestSourceExclude = req.query._source_exclude || []
+        _source_include = [...includeFields, ...requestSourceInclude]
+        _source_exclude = [...excludeFields, ...requestSourceExclude]
       }
 
       const urlParams = {

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -123,8 +123,8 @@ export default ({config, db}) => async function (req, res, body) {
           return object
         }, {})
 
-      let _source_include = includeFields
-      let _source_exclude = excludeFields
+      let _source_include = includeFields || []
+      let _source_exclude = excludeFields || []
 
       if (!config.elasticsearch.overwriteRequestSourceParams) {
         const requestSourceInclude = req.query._source_include || []

--- a/src/lib/elastic.js
+++ b/src/lib/elastic.js
@@ -3,6 +3,7 @@ const _ = require('lodash')
 const fs = require('fs');
 const jsonFile = require('jsonfile')
 const es = require('@elastic/elasticsearch')
+const querystring = require('querystring')
 
 function _updateQueryStringParameter (uri, key, value) {
   var re = new RegExp('([?&])' + key + '=.*?(&|#|$)', 'i');
@@ -29,6 +30,39 @@ function adjustIndexName (indexName, entityType, config) {
   } else {
     return `${indexName}_${entityType}`
   }
+}
+
+function decorateBackendUrl (entityType, url, req, config) {
+  if (config.elasticsearch.useRequestFilter && typeof config.entities[entityType] === 'object') {
+    const urlParts = url.split('?')
+    const { includeFields, excludeFields } = config.entities[entityType]
+
+    const filteredParams = Object.keys(req.query)
+      .filter(key => !config.elasticsearch.requestParamsBlacklist.includes(key))
+      .reduce((object, key) => {
+        object[key] = req.query[key]
+        return object
+      }, {})
+
+    let _source_include = includeFields || []
+    let _source_exclude = excludeFields || []
+
+    if (!config.elasticsearch.overwriteRequestSourceParams) {
+      const requestSourceInclude = req.query._source_include || []
+      const requestSourceExclude = req.query._source_exclude || []
+      _source_include = [...includeFields, ...requestSourceInclude]
+      _source_exclude = [...excludeFields, ...requestSourceExclude]
+    }
+
+    const urlParams = {
+      ...filteredParams,
+      _source_include,
+      _source_exclude
+    }
+    url = `${urlParts[0]}?${querystring.stringify(urlParams)}`
+  }
+
+  return url
 }
 
 function adjustBackendProxyUrl (req, indexName, entityType, config) {
@@ -58,7 +92,8 @@ function adjustBackendProxyUrl (req, indexName, entityType, config) {
   if (!url.startsWith('http')) {
     url = config.elasticsearch.protocol + '://' + url
   }
-  return url
+
+  return decorateBackendUrl(entityType, url, req, config)
 }
 
 function adjustQuery (esQuery, entityType, config) {


### PR DESCRIPTION
Added 3 configuration values:

```{
  "elasticsearch":
    "useRequestFilter": false,
    "overwriteRequestSourceParams": false,
    "requestParamsBlacklist": [], 
  }
}
```

`useRequestFilter` is responsible for enabling/disabling ES request filtering
`overwriteRequestSourceParams` decide if you want to overwrite or merge values
`requestParamsBlacklist` allow you to filter out selected attributes
