### PR TITLE
Fix default value for `maxAgeForResponse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.2] - UNRELEASED
+
+### Fixed
+
+- Fix default value for `maxAgeForResponse` - @lauraseidler (#485)
 
 ## [1.12.1] - 2020.06.22
 

--- a/src/image/action/local/index.ts
+++ b/src/image/action/local/index.ts
@@ -12,7 +12,7 @@ export default class LocalImageAction extends ImageAction {
   }
 
   public get maxAgeForResponse () {
-    return 31557600000
+    return 365.25 * 86400
   }
 
   public getImageURL (): string {


### PR DESCRIPTION
This value is used as the default value for the `Cache-Control: max-age=XXXXXX` header - which is measured in seconds, not milliseconds - making the current default value equal to 365250 days instead of 365.25 as I assume was the intention.

To make it clearer what this value is supposed to be, I think it makes sense to use a calculation here instead of just a number.