### PR TITLE
Add support for SVG files

### DIFF
--- a/src/api/img.js
+++ b/src/api/img.js
@@ -44,5 +44,5 @@ export default ({ config, db }) =>
     return res
       .type(imageAction.mimeType)
       .set({ 'Cache-Control': `max-age=${imageAction.maxAgeForResponse}` })
-      .send(imageBuffer);
+      .send(imageAction.mimeType === 'image/svg+xml' ? imageBuffer.toString() : imageBuffer);
   });

--- a/src/image/action/local/index.ts
+++ b/src/image/action/local/index.ts
@@ -93,6 +93,9 @@ export default class LocalImageAction extends ImageAction {
         result: `Unable to download the requested image ${imgUrl}`
       })
     }
+    if (this.mimeType === 'image/svg+xml') {
+      return this.imageBuffer
+    }
     const { action, width, height } = this.imageOptions
     switch (action) {
       case 'resize':


### PR DESCRIPTION
The VSF API doesn't process SVG files. It simply returns an empty response. Since SVG files are vector I skipped the resize and cropping and return the SVG files as they are originally, using the toStrong method because they need to be returned as text. 