### PR TITLE
Added optional customer token for create order

### DIFF
--- a/src/api/order.ts
+++ b/src/api/order.ts
@@ -61,6 +61,11 @@ export default ({ config, db }) => resource({
       }
     }
 
+    let token = null
+    if (req.query && req.query.token) {
+        token = req.query.token
+    }
+
     if (config.orders.useServerQueue) {
       try {
         let queue = kue.createQueue(Object.assign(config.kue, { redis: config.redis }));
@@ -77,7 +82,7 @@ export default ({ config, db }) => resource({
       }
     } else {
       const orderProxy = _getProxy(req, config)
-      orderProxy.create(req.body).then((result) => {
+      orderProxy.create(req.body, token).then((result) => {
         apiStatus(res, result, 200);
       }).catch(err => {
         apiError(res, err);

--- a/src/platform/magento2/order.js
+++ b/src/platform/magento2/order.js
@@ -10,7 +10,7 @@ class OrderProxy extends AbstractOrderProxy {
     this.api = Magento2Client(multiStoreConfig(config.magento2.api, req));
   }
 
-  create (orderData) {
+  create (orderData, customerToken = null) {
     const inst = this
     return new Promise((resolve, reject) => {
       try {
@@ -18,7 +18,7 @@ class OrderProxy extends AbstractOrderProxy {
           console.log(error)
           if (error) reject(error)
           resolve(result)
-        })
+        }, customerToken)
       } catch (e) {
         reject(e)
       }


### PR DESCRIPTION
Closes #501 

I wasn't sure of the best way to approach this as it is specific to Magento. I tried taking the advise of @pkarw to only work in the `src/api/platform` level, but passing the customer token as a parameter has to be handled in `src/api/order.ts` somehow, and then passed to the proxy. I tried to do this in the least intrusive way I could find, but I don't know how it will impact other platform proxies.

Alternatively, we could potentially add the token to the `req.body` instead, and then extract it in the Magento 2 proxy, or directly in `o2m.js`, but I don't know if forcing an additional property to the `req.body` in the API is a good idea.

Any suggestions or recommendations are welcome.