### PR TITLE
Add extended ElasticSearch 7+ support and more flexibility to `elastic` lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.12.4] - Unreleased
 
 ### Fixed 
- * add try catch to jwt.decode for groupId which is needed when you change the key for the JWT @resubaka (#496)
+
+ - add try catch to jwt.decode for groupId which is needed when you change the key for the JWT - @resubaka (#496)
+
+### Added
+
+ - Add extended ElasticSearch 7+ support and more flexibility to `elastic` lib - @cewald (#512)
  
 ## [1.12.3] - 2020.07.23
 

--- a/config/default.json
+++ b/config/default.json
@@ -356,7 +356,7 @@
       },
       "product": {
         "excludeFields": [ "updated_at", "created_at", "attribute_set_id", "status", "visibility", "tier_prices", "options_container", "msrp_display_actual_price_type", "has_options", "stock.manage_stock", "stock.use_config_min_qty", "stock.use_config_notify_stock_qty", "stock.stock_id",  "stock.use_config_backorders", "stock.use_config_enable_qty_inc", "stock.enable_qty_increments", "stock.use_config_manage_stock", "stock.use_config_min_sale_qty", "stock.notify_stock_qty", "stock.use_config_max_sale_qty", "stock.use_config_max_sale_qty", "stock.qty_increments", "small_image"],
-        "includeFields": null,
+        "includeFields": [],
         "filterFieldMapping": {
           "category.name": "category.name.keyword"
         }

--- a/config/default.json
+++ b/config/default.json
@@ -27,6 +27,7 @@
     "port": 9200,
     "protocol": "http",
     "requestTimeout": 5000,
+    "pingTimeout": 1000,
     "min_score": 0.01,
     "indices": [
       "vue_storefront_catalog",

--- a/src/api/attribute/service.ts
+++ b/src/api/attribute/service.ts
@@ -118,7 +118,6 @@ async function list (attributesParam: AttributeListParam, config, indexName: str
   try {
     const query = adjustQuery({
       index: indexName,
-      type: 'attribute',
       body: bodybuilder().filter('terms', 'attribute_code', attributeCodes).build()
     }, 'attribute', config)
     const response = await getElasticClient(config).search(query)

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -104,7 +104,7 @@ export default ({config, db}) => async function (req, res, body) {
   const reqHash = sha3_224(`${JSON.stringify(requestBody)}${req.url}`)
   const dynamicRequestHandler = () => {
     const reqQuery = Object.assign({}, req.query)
-    const reqQueryParams = adjustQueryParams(reqQuery, config)
+    const reqQueryParams = adjustQueryParams(reqQuery, entityType, config)
 
     const query = adjustQuery({
       index: indexName,

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -1,7 +1,6 @@
 import jwt from 'jwt-simple'
-import request from 'request'
 import ProcessorFactory from '../processor/factory'
-import { adjustBackendProxyUrl, getTotals } from '../lib/elastic'
+import { getClient as esClient, adjustQuery, adjustQueryParams, getTotals } from '../lib/elastic'
 import cache from '../lib/cache-instance'
 import { sha3_224 } from 'js-sha3'
 import AttributeService from './attribute/service'
@@ -83,11 +82,8 @@ export default ({config, db}) => async function (req, res, body) {
     }
   }
 
-  // pass the request to elasticsearch
-  const elasticBackendUrl = adjustBackendProxyUrl(req, indexName, entityType, config)
-  const userToken = requestBody.groupToken
-
   // Decode token and get group id
+  const userToken = requestBody.groupToken
   if (userToken && userToken.length > 10) {
     /**
      * We need to use try catch so when we change the keys for encryption that not every request with a loggedin user
@@ -104,78 +100,80 @@ export default ({config, db}) => async function (req, res, body) {
   delete requestBody.groupToken
   delete requestBody.groupId
 
-  let auth = null
-
-  // Only pass auth if configured
-  if (config.elasticsearch.user || config.elasticsearch.password) {
-    auth = {
-      user: config.elasticsearch.user,
-      pass: config.elasticsearch.password
-    }
-  }
   const s = Date.now()
   const reqHash = sha3_224(`${JSON.stringify(requestBody)}${req.url}`)
   const dynamicRequestHandler = () => {
-    request({ // do the elasticsearch request
-      uri: elasticBackendUrl,
+    const reqQuery = Object.assign({}, req.query)
+    const reqQueryParams = adjustQueryParams(reqQuery, config)
+
+    const query = adjustQuery({
+      index: indexName,
       method: req.method,
-      body: requestBody,
-      json: true,
-      auth: auth
-    }, async (_err, _res, _resBody) => { // TODO: add caching layer to speed up SSR? How to invalidate products (checksum on the response BEFORE processing it)
-      if (_err || _resBody.error) {
-        console.error(_err || _resBody.error)
-        apiError(res, _err || _resBody.error)
-        return
-      }
-      try {
-        if (_resBody && _resBody.hits && _resBody.hits.hits) { // we're signing up all objects returned to the client to be able to validate them when (for example order)
-          const factory = new ProcessorFactory(config)
-          const tagsArray = []
-          if (config.server.useOutputCache && cache) {
-            const tagPrefix = entityType[0].toUpperCase() // first letter of entity name: P, T, A ...
-            tagsArray.push(entityType)
-            _resBody.hits.hits.map(item => {
-              if (item._source.id) { // has common identifier
-                tagsArray.push(`${tagPrefix}${item._source.id}`)
-              }
-            })
-            const cacheTags = tagsArray.join(' ')
-            res.setHeader('X-VS-Cache-Tags', cacheTags)
-          }
+      body: requestBody
+    }, entityType, config)
 
-          let resultProcessor = factory.getAdapter(entityType, indexName, req, res)
+    esClient(config)
+      .search(Object.assign(query, reqQueryParams))
+      .then(async response => {
+        let { body: _resBody } = response
 
-          if (!resultProcessor) { resultProcessor = factory.getAdapter('default', indexName, req, res) } // get the default processor
-
-          const productGroupId = entityType === 'product' ? groupId : undefined
-          const result = await resultProcessor.process(_resBody.hits.hits, productGroupId)
-          _resBody.hits.hits = result
-          if (entityType === 'product' && _resBody.aggregations && config.entities.attribute.loadByAttributeMetadata) {
-            const attributeListParam = AttributeService.transformAggsToAttributeListParam(_resBody.aggregations)
-            // find attribute list
-            const attributeList = await AttributeService.list(attributeListParam, config, indexName)
-            _resBody.attribute_metadata = attributeList.map(AttributeService.transformToMetadata)
-          }
-
-          _resBody = _outputFormatter(_resBody, responseFormat)
-
-          if (config.get('varnish.enabled')) {
-            // Add tags to cache, so we can display them in response headers then
-            _cacheStorageHandler(config, {
-              ..._resBody,
-              tags: tagsArray
-            }, reqHash, tagsArray)
-          } else {
-            _cacheStorageHandler(config, _resBody, reqHash, tagsArray)
-          }
+        if (_resBody.error) {
+          console.error('An error occured during catalog request:', _resBody.error)
+          apiError(res, _resBody.error)
+          return
         }
 
-        res.json(_resBody)
-      } catch (err) {
+        try {
+          if (_resBody && _resBody.hits && _resBody.hits.hits) { // we're signing up all objects returned to the client to be able to validate them when (for example order)
+            const factory = new ProcessorFactory(config)
+            const tagsArray = []
+            if (config.server.useOutputCache && cache) {
+              const tagPrefix = entityType[0].toUpperCase() // first letter of entity name: P, T, A ...
+              tagsArray.push(entityType)
+              _resBody.hits.hits.map(item => {
+                if (item._source.id) { // has common identifier
+                  tagsArray.push(`${tagPrefix}${item._source.id}`)
+                }
+              })
+              const cacheTags = tagsArray.join(' ')
+              res.setHeader('X-VS-Cache-Tags', cacheTags)
+            }
+
+            let resultProcessor = factory.getAdapter(entityType, indexName, req, res)
+
+            if (!resultProcessor) { resultProcessor = factory.getAdapter('default', indexName, req, res) } // get the default processor
+
+            const productGroupId = entityType === 'product' ? groupId : undefined
+            const result = await resultProcessor.process(_resBody.hits.hits, productGroupId)
+            _resBody.hits.hits = result
+            if (entityType === 'product' && _resBody.aggregations && config.entities.attribute.loadByAttributeMetadata) {
+              const attributeListParam = AttributeService.transformAggsToAttributeListParam(_resBody.aggregations)
+              // find attribute list
+              const attributeList = await AttributeService.list(attributeListParam, config, indexName)
+              _resBody.attribute_metadata = attributeList.map(AttributeService.transformToMetadata)
+            }
+
+            _resBody = _outputFormatter(_resBody, responseFormat)
+
+            if (config.get('varnish.enabled')) {
+              // Add tags to cache, so we can display them in response headers then
+              _cacheStorageHandler(config, {
+                ..._resBody,
+                tags: tagsArray
+              }, reqHash, tagsArray)
+            } else {
+              _cacheStorageHandler(config, _resBody, reqHash, tagsArray)
+            }
+          }
+
+          res.json(_resBody)
+        } catch (err) {
+          apiError(res, err)
+        }
+      })
+      .catch(err => {
         apiError(res, err)
-      }
-    })
+      })
   }
 
   if (config.server.useOutputCache && cache) {

--- a/src/lib/elastic.js
+++ b/src/lib/elastic.js
@@ -77,6 +77,24 @@ function adjustBackendProxyUrl (req, indexName, entityType, config) {
   return decorateBackendUrl(entityType, url, req, config)
 }
 
+function adjustQueryParams (query, config) {
+  if (parseInt(config.elasticsearch.apiVersion) < 6) { // legacy for ES 5
+    delete query.request
+    delete query.request_format
+    delete query.response_format
+  } else {
+    query._source_includes = query._source_include
+    query._source_excludes = query._source_exclude
+    delete query._source_exclude
+    delete query._source_include
+    delete query.request
+    delete query.request_format
+    delete query.response_format
+  }
+
+  return query
+}
+
 function adjustQuery (esQuery, entityType, config) {
   if (parseInt(config.elasticsearch.apiVersion) < 6) {
     esQuery.type = entityType
@@ -305,6 +323,7 @@ module.exports = {
   reIndex,
   search,
   adjustQuery,
+  adjustQueryParams,
   adjustBackendProxyUrl,
   getClient,
   getHits,

--- a/src/lib/elastic.js
+++ b/src/lib/elastic.js
@@ -165,9 +165,7 @@ function getClient (config) {
     auth = { username: user, password }
   }
 
-  if (!esClient) {
-    esClient = new es.Client({ nodes, auth, apiVersion, requestTimeout, pingTimeout })
-  }
+  esClient = new es.Client({ nodes, auth, apiVersion, requestTimeout, pingTimeout })
 
   return esClient
 }

--- a/src/lib/elastic.js
+++ b/src/lib/elastic.js
@@ -121,7 +121,10 @@ function adjustBackendProxyUrl (req, indexName, entityType, config) {
 function adjustQuery (esQuery, entityType, config) {
   if (parseInt(config.elasticsearch.apiVersion) < 6) {
     esQuery.type = entityType
+  } else {
+    delete esQuery.type
   }
+
   esQuery.index = adjustIndexName(esQuery.index, entityType, config)
   return esQuery
 }

--- a/src/lib/elastic.js
+++ b/src/lib/elastic.js
@@ -5,25 +5,6 @@ const jsonFile = require('jsonfile')
 const es = require('@elastic/elasticsearch')
 const querystring = require('querystring')
 
-function _updateQueryStringParameter (uri, key, value) {
-  var re = new RegExp('([?&])' + key + '=.*?(&|#|$)', 'i');
-  if (uri.match(re)) {
-    if (value) {
-      return uri.replace(re, '$1' + key + '=' + value + '$2');
-    } else {
-      return uri.replace(re, '$1' + '$2');
-    }
-  } else {
-    var hash = '';
-    if (uri.indexOf('#') !== -1) {
-      hash = uri.replace(/.*#/, '#');
-      uri = uri.replace(/#.*/, '');
-    }
-    var separator = uri.indexOf('?') !== -1 ? '&' : '?';
-    return uri + separator + key + '=' + value + hash;
-  }
-}
-
 function adjustIndexName (indexName, entityType, config) {
   if (parseInt(config.elasticsearch.apiVersion) < 6) {
     return indexName

--- a/src/lib/elastic.js
+++ b/src/lib/elastic.js
@@ -101,8 +101,15 @@ const getTotals = body => typeof body.hits.total === 'object' ? body.hits.total.
 
 let esClient = null
 function getClient (config) {
-  let { host, port, protocol, apiVersion, requestTimeout } = config.elasticsearch
-  const node = `${protocol}://${host}:${port}`
+  let { host, port, protocol, apiVersion, requestTimeout, pingTimeout } = config.elasticsearch
+
+  let nodes = []
+  let hosts = typeof host === 'string' ? host.split(',') : host
+
+  hosts.forEach(host => {
+    const node = `${protocol}://${host}:${port}`
+    nodes.push(node)
+  })
 
   let auth
   if (config.elasticsearch.user) {
@@ -111,7 +118,7 @@ function getClient (config) {
   }
 
   if (!esClient) {
-    esClient = new es.Client({ node, auth, apiVersion, requestTimeout })
+    esClient = new es.Client({ nodes, auth, apiVersion, requestTimeout, pingTimeout })
   }
 
   return esClient

--- a/src/lib/elastic.js
+++ b/src/lib/elastic.js
@@ -93,6 +93,12 @@ function getHits (result) {
   }
 }
 
+/**
+ * Support for ES7+ where the `total` now is an object
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html
+ */
+const getTotals = body => typeof body.hits.total === 'object' ? body.hits.total.value : body.hits.total
+
 let esClient = null
 function getClient (config) {
   let { host, port, protocol, apiVersion, requestTimeout } = config.elasticsearch
@@ -295,6 +301,7 @@ module.exports = {
   adjustBackendProxyUrl,
   getClient,
   getHits,
+  getTotals,
   adjustIndexName,
   putMappings
 }

--- a/src/lib/elastic.js
+++ b/src/lib/elastic.js
@@ -145,6 +145,10 @@ const getTotals = body => typeof body.hits.total === 'object' ? body.hits.total.
 
 let esClient = null
 function getClient (config) {
+  if (esClient) {
+    return esClient
+  }
+  
   let { host, port, protocol, apiVersion, requestTimeout, pingTimeout } = config.elasticsearch
 
   let nodes = []


### PR DESCRIPTION
I've recently switched to ES7 and notices some incompatibilities in the API.

These are some proposals to have a more stable support for the current ES version and more flexibility:
* Remove type attribute from `attribute/service/list` method as it is already resolved by the `adjustQuery` depending on its version and will drop an ES exception if it is left in the search query
*  Remove `_updateQueryStringParameter` method as it is unused as it is nowhere called
* Add `getTotals` method to `elastic` lib as from ES7 the totals return [value is an object](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#hits-total-now-object-search-response)
* Add `pingTimeout` option and possibility for multiple ES hosts to `elastic` lib
* Use `elasticsearch` client library in catalog endpoint to make ES settings more consistent 

I can make these changes for the `storefront-api` repo too if you wan't.