### PR TITLE
Increase body parser limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.4] - 2020.07.23
+
+### Fixed
+
+- Increase body parser limit - @rozzilla
+
 ## [1.12.3] - 2020.07.23
 
 ### Fixed

--- a/config/default.json
+++ b/config/default.json
@@ -242,7 +242,7 @@
   "review": {
     "defaultReviewStatus": 2
   },
-  "bodyLimit": "100kb",
+  "bodyLimit": "1500kb",
   "corsHeaders": [
     "Link"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-storefront-api",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "private": true,
   "description": "vue-storefront API and data services",
   "main": "dist",


### PR DESCRIPTION
I've received many exceptions `PayloadTooLargeError` on live VSF environment.
The specific case was caused by the send order method, that send a JSON object bigger than 100kb.
So I strongly recommend updating this value on the default.json