### PR TITLE
Add payment-information endpoint to cart api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added webp support for local image action - @gibkigonzo (#409)
+- Added payment-information endpoint to cart api - [@rain2o](https://github.com/rain2o) (#538)
 
 ### Fixed 
  * add try catch to jwt.decode for groupId which is needed when you change the key for the JWT @resubaka (#496)

--- a/src/api/cart.ts
+++ b/src/api/cart.ts
@@ -224,5 +224,23 @@ export default ({ config, db }) => {
     })
   })
 
+  /**
+   * POST /payment-information - Set payment information and place order for a specified cart.
+   *   req.query.token | req.headers.authorization - user token
+   *   req.query.cartId - cart ID if user is logged in, cart token if not
+   *   req.body - payment and order information
+   */
+  cartApi.post('/payment-information', (req, res) => {
+    const cartProxy = _getProxy(req)
+    const token = getToken(req)
+    res.setHeader('Cache-Control', 'no-cache, no-store');
+
+    cartProxy.paymentInformationAndOrder(token, req.query.cartId ? req.query.cartId : null, req.body).then((result) => {
+      apiStatus(res, result, 200);
+    }).catch(err => {
+      apiError(res, err);
+    })
+  })
+
   return cartApi
 }


### PR DESCRIPTION
Closes #538 

Adds new endpoint to cart API to save payment information and order in Magento 2 so it can be completed later.